### PR TITLE
Fixed removeDataTable() so that there's no indexing issue

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -11,6 +11,8 @@ Notes for major and minor releases. Notes for Patch releases are deferred.
 
 .. **Of interest to the User**:
 
+.. PR #171: Fixed removing tab index issue
+
 .. **Of interest to the Developer:**
 
 v4.5.0

--- a/src/quicknxs/interfaces/main_window.py
+++ b/src/quicknxs/interfaces/main_window.py
@@ -430,14 +430,20 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def addDataTable(self):
         """Add data tab for additional peaks/ROIs."""
-        next_tab_idx = self.data_tab_count + 1
-        self.ui.tabWidget.setTabVisible(next_tab_idx, True)
-        self.data_manager.add_additional_reduction_list(next_tab_idx)
-        self.file_handler.initialize_additional_reduction_table(next_tab_idx)
-        self.data_tab_count += 1
-        self.ui.removeTabButton.setEnabled(True)
-        if self.data_tab_count == self.max_data_tab_count:
-            self.ui.addTabButton.setEnabled(False)
+        self.ui.addTabButton.setEnabled(False)  # Disable the `addTabButton` at the beginning
+        try:
+            next_tab_idx = self.data_tab_count + 1
+            self.ui.tabWidget.setTabVisible(next_tab_idx, True)
+            self.data_manager.add_additional_reduction_list(next_tab_idx)
+            self.file_handler.initialize_additional_reduction_table(next_tab_idx)
+            self.data_tab_count += 1
+            self.ui.removeTabButton.setEnabled(True)
+            if self.data_tab_count == self.max_data_tab_count:
+                self.ui.addTabButton.setEnabled(False)
+        finally:
+            # Re-enable the `addTabButton` if tabs still remain and no exceptions occurred
+            if self.data_tab_count > self.min_data_tab_count:
+                self.ui.addTabButton.setEnabled(True)
 
     def removeDataTable(self):
         """Remove last data tab for additional peaks/ROI:s"""

--- a/src/quicknxs/interfaces/main_window.py
+++ b/src/quicknxs/interfaces/main_window.py
@@ -441,7 +441,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def removeDataTable(self):
         """Remove last data tab for additional peaks/ROI:s"""
-        self.ui.removeTabButton.setEnabled(False) # Disable the `removeTabButton` at the beginning
+        self.ui.removeTabButton.setEnabled(False)  # Disable the `removeTabButton` at the beginning
         try:
             self.ui.tabWidget.setTabVisible(self.data_tab_count, False)
             self.data_manager.remove_additional_reduction_list(self.data_tab_count)

--- a/src/quicknxs/interfaces/main_window.py
+++ b/src/quicknxs/interfaces/main_window.py
@@ -442,7 +442,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.ui.addTabButton.setEnabled(False)
         finally:
             # Re-enable the `addTabButton` if tabs still remain and no exceptions occurred
-            if self.data_tab_count > self.min_data_tab_count:
+            if self.data_tab_count > self.min_data_tab_count and self.data_tab_count < self.max_data_tab_count:
                 self.ui.addTabButton.setEnabled(True)
 
     def removeDataTable(self):

--- a/src/quicknxs/interfaces/main_window.py
+++ b/src/quicknxs/interfaces/main_window.py
@@ -440,13 +440,19 @@ class MainWindow(QtWidgets.QMainWindow):
             self.ui.addTabButton.setEnabled(False)
 
     def removeDataTable(self):
-        """Remove last data tab for additional peaks/ROIs."""
-        self.ui.tabWidget.setTabVisible(self.data_tab_count, False)
-        self.data_manager.remove_additional_reduction_list(self.data_tab_count)
-        self.data_tab_count -= 1
-        self.ui.addTabButton.setEnabled(True)
-        if self.data_tab_count == self.min_data_tab_count:
-            self.ui.removeTabButton.setEnabled(False)
+        """Remove last data tab for additional peaks/ROI:s"""
+        self.ui.removeTabButton.setEnabled(False) # Disable the `removeTabButton` at the beginning
+        try:
+            self.ui.tabWidget.setTabVisible(self.data_tab_count, False)
+            self.data_manager.remove_additional_reduction_list(self.data_tab_count)
+            self.data_tab_count -= 1
+            self.ui.addTabButton.setEnabled(True)
+            if self.data_tab_count == self.min_data_tab_count:
+                self.ui.removeTabButton.setEnabled(False)
+        finally:
+            # Re-enable the `removeTabButton` if tabs still remain and no exceptions occurred
+            if self.data_tab_count > self.min_data_tab_count:
+                self.ui.removeTabButton.setEnabled(True)
 
     def add_data_tab_by_index(self, tab_index: int):
         """Add/update a specific data tab."""


### PR DESCRIPTION
## Description of work:

removeDataTable() was updated so that there would be no indexing issue. The remove tab button is disabled until the tab is successfully removed.

Check all that apply:
- [x] added [release notes](https://reflectivity-ui.readthedocs.io/en/latest/releasenotes/index.html)
(if not, provide an explanation in the work description)
- [ ] updated documentation and checked that it looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [x] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests

**References:**
- Links to IBM EWM items: [11254](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=11254)
- Links to related issues or pull requests:


# :warning: Manual test for the reviewer
([instructions to set up the environment](https://reflectivity-ui.readthedocs.io/en/latest/developer/environment.html))

First, do the following on next:
1. Load a data file 
2. Add dataset to reduction list
3. Add 3 new data tabs
4. Click last tab "Data (ROI 4)"
5. Spam the remove tab button
6. Try to right click

Right clicking won't showing anything and you should see an error on the terminal. Now, do the above again but with the fixed branch. You should no longer see the error.

# Check list for the reviewer
- [ ] [release notes](https://reflectivity-ui.readthedocs.io/en/latest/releasenotes/index.html) updated,
or an explanation is provided as to why release notes are unnecessary
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date and looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] code comments added when explaining intent
