### PR TITLE
Make package name a variable in github action

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -135,6 +135,18 @@ jobs:
     needs: [tests, build, conda-verify]
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 100
+          fetch-tags: true
+          ref: ${{ github.ref }}
+
+      - name: Setup Pixi
+        uses: prefix-dev/setup-pixi@v0.8.10
+        with:
+          pixi-version: v0.48.2
+
       - name: Download conda package artifact
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
Low priority, but this improves reusability for users who may want to copy-paste the build and deploy portion of the action into other projects. 

Also improves this as a stub for a potential future custom github action