### PR TITLE
Consolidate reflectivity and intensity plots into one widget

### DIFF
--- a/src/quicknxs/interfaces/event_handlers/main_handler.py
+++ b/src/quicknxs/interfaces/event_handlers/main_handler.py
@@ -185,10 +185,7 @@ class MainHandler(object):
         self.main_window.auto_change_active = False
 
         self.main_window.file_loaded_signal.emit()
-        if self.main_window.data_manager.active_cross_section.is_direct_beam:
-            self.main_window.initiate_intensity_plot.emit(False)
-        else:
-            self.main_window.initiate_reflectivity_plot.emit(False)
+        self.main_window.initiate_reflectivity_or_intensity_plot.emit(False)
         self.main_window.initiate_projection_plot.emit(False)
         self.cache_indicator.setText("Files loaded: %s" % (self._data_manager.get_cachesize()))
 
@@ -197,10 +194,7 @@ class MainHandler(object):
         self._set_data_manager_active_cross_section()
         self.update_cross_section_info()
         self.main_window.plotActiveTab()
-        if self.main_window.data_manager.active_cross_section.is_direct_beam:
-            self.main_window.initiate_intensity_plot.emit(False)
-        else:
-            self.main_window.initiate_reflectivity_plot.emit(False)
+        self.main_window.initiate_reflectivity_or_intensity_plot.emit(False)
         self.main_window.initiate_projection_plot.emit(False)
 
     def _set_data_manager_active_cross_section(self):
@@ -811,7 +805,7 @@ class MainHandler(object):
         self.ui.reductionTable.insertRow(idx)
         self.update_tables()
 
-        self.main_window.initiate_reflectivity_plot.emit(True)
+        self.main_window.initiate_reflectivity_or_intensity_plot.emit(True)
         self.main_window.update_specular_viewer.emit()
         self.main_window.auto_change_active = False
         return True
@@ -882,8 +876,7 @@ class MainHandler(object):
         # remove additional data tabs
         self.main_window.reset_data_tabs()
 
-        if self.main_window.refl.isVisible():
-            self.main_window.initiate_reflectivity_plot.emit(False)
+        self.main_window.initiate_reflectivity_or_intensity_plot.emit(False)
 
     def remove_reflectivity(self):
         """Remove one item from the reduction list."""
@@ -892,7 +885,7 @@ class MainHandler(object):
             return
         self._data_manager.reduction_list.pop(index)
         self.reduction_table.removeRow(index)
-        self.main_window.initiate_reflectivity_plot.emit(False)
+        self.main_window.initiate_reflectivity_or_intensity_plot.emit(False)
 
     def reduction_table_changed(self, item: QtWidgets.QTableWidgetItem):
         """Perform action upon change in data reduction list."""
@@ -973,7 +966,7 @@ class MainHandler(object):
                 )
 
         self.main_window.plotActiveTab()
-        self.main_window.initiate_reflectivity_plot.emit(True)
+        self.main_window.initiate_reflectivity_or_intensity_plot.emit(True)
         self.main_window.update_specular_viewer.emit()
 
     def add_direct_beam(self, silent=False):
@@ -995,7 +988,7 @@ class MainHandler(object):
         direct_beam_ids = [str(r.number) for r in self._data_manager.direct_beam_list]
         self.ui.direct_beam_list_label.setText(", ".join(direct_beam_ids))
 
-        self.main_window.initiate_intensity_plot.emit(False)
+        self.main_window.initiate_reflectivity_or_intensity_plot.emit(False)
         return True
 
     def remove_direct_beam(self):
@@ -1005,14 +998,14 @@ class MainHandler(object):
             return
         self._data_manager.direct_beam_list.pop(index)
         self.ui.directBeamTable.removeRow(index)
-        self.main_window.initiate_intensity_plot.emit(False)
+        self.main_window.initiate_reflectivity_or_intensity_plot.emit(False)
 
     def clear_direct_beams(self):
         """Remove all items from the direct beam list."""
         self._data_manager.clear_direct_beam_list()
         self.ui.directBeamTable.setRowCount(0)
         self.ui.direct_beam_list_label.setText("None")
-        self.main_window.initiate_intensity_plot.emit(False)
+        self.main_window.initiate_reflectivity_or_intensity_plot.emit(False)
 
     def update_direct_beam_table(self, idx: int, data: CrossSectionData) -> None:
         """Update a direct beam table entry with cross-section data.
@@ -1107,7 +1100,7 @@ class MainHandler(object):
             )
 
         self.main_window.plotActiveTab()
-        self.main_window.initiate_intensity_plot.emit(True)
+        self.main_window.initiate_reflectivity_or_intensity_plot.emit(True)
         self.main_window.initiate_projection_plot.emit(True)
 
     def active_data_changed(self):
@@ -1628,7 +1621,7 @@ class MainHandler(object):
                     i, 1, QtWidgets.QTableWidgetItem("%.4f" % (d.configuration.scaling_factor))
                 )
 
-            self.main_window.initiate_reflectivity_plot.emit(False)
+            self.main_window.initiate_reflectivity_or_intensity_plot.emit(False)
 
     def trim_data_to_normalization(self):
         """Cut the start and end of the active data set to 5% of its maximum intensity."""
@@ -1637,7 +1630,7 @@ class MainHandler(object):
             self.ui.rangeStart.setValue(trim_points[0])
             self.ui.rangeEnd.setValue(trim_points[1])
             self.update_tables()
-            self.main_window.initiate_reflectivity_plot.emit(False)
+            self.main_window.initiate_reflectivity_or_intensity_plot.emit(False)
         else:
             self.report_message("No direct beam found to trim data", pop_up=False)
 
@@ -1650,7 +1643,7 @@ class MainHandler(object):
             d = self._data_manager.reduction_list[i].cross_sections[xs]
             self.reduction_table.setItem(i, 3, QtWidgets.QTableWidgetItem(str(d.configuration.cut_last_n_points)))
 
-        self.main_window.initiate_reflectivity_plot.emit(False)
+        self.main_window.initiate_reflectivity_or_intensity_plot.emit(False)
 
     def reload_all_files(self):
         """Reload all files upon change in loading configuration.

--- a/src/quicknxs/interfaces/event_handlers/main_handler.py
+++ b/src/quicknxs/interfaces/event_handlers/main_handler.py
@@ -185,7 +185,7 @@ class MainHandler(object):
         self.main_window.auto_change_active = False
 
         self.main_window.file_loaded_signal.emit()
-        self.main_window.initiate_reflectivity_or_intensity_plot.emit(False)
+        self.main_window.initiate_reflectivity_or_intensity_plot.emit()
         self.main_window.initiate_projection_plot.emit(False)
         self.cache_indicator.setText("Files loaded: %s" % (self._data_manager.get_cachesize()))
 
@@ -194,7 +194,7 @@ class MainHandler(object):
         self._set_data_manager_active_cross_section()
         self.update_cross_section_info()
         self.main_window.plotActiveTab()
-        self.main_window.initiate_reflectivity_or_intensity_plot.emit(False)
+        self.main_window.initiate_reflectivity_or_intensity_plot.emit()
         self.main_window.initiate_projection_plot.emit(False)
 
     def _set_data_manager_active_cross_section(self):
@@ -805,7 +805,7 @@ class MainHandler(object):
         self.ui.reductionTable.insertRow(idx)
         self.update_tables()
 
-        self.main_window.initiate_reflectivity_or_intensity_plot.emit(True)
+        self.main_window.initiate_reflectivity_or_intensity_plot.emit()
         self.main_window.update_specular_viewer.emit()
         self.main_window.auto_change_active = False
         return True
@@ -876,7 +876,7 @@ class MainHandler(object):
         # remove additional data tabs
         self.main_window.reset_data_tabs()
 
-        self.main_window.initiate_reflectivity_or_intensity_plot.emit(False)
+        self.main_window.initiate_reflectivity_or_intensity_plot.emit()
 
     def remove_reflectivity(self):
         """Remove one item from the reduction list."""
@@ -885,7 +885,7 @@ class MainHandler(object):
             return
         self._data_manager.reduction_list.pop(index)
         self.reduction_table.removeRow(index)
-        self.main_window.initiate_reflectivity_or_intensity_plot.emit(False)
+        self.main_window.initiate_reflectivity_or_intensity_plot.emit()
 
     def reduction_table_changed(self, item: QtWidgets.QTableWidgetItem):
         """Perform action upon change in data reduction list."""
@@ -966,7 +966,7 @@ class MainHandler(object):
                 )
 
         self.main_window.plotActiveTab()
-        self.main_window.initiate_reflectivity_or_intensity_plot.emit(True)
+        self.main_window.initiate_reflectivity_or_intensity_plot.emit()
         self.main_window.update_specular_viewer.emit()
 
     def add_direct_beam(self, silent=False):
@@ -988,7 +988,7 @@ class MainHandler(object):
         direct_beam_ids = [str(r.number) for r in self._data_manager.direct_beam_list]
         self.ui.direct_beam_list_label.setText(", ".join(direct_beam_ids))
 
-        self.main_window.initiate_reflectivity_or_intensity_plot.emit(False)
+        self.main_window.initiate_reflectivity_or_intensity_plot.emit()
         return True
 
     def remove_direct_beam(self):
@@ -998,14 +998,14 @@ class MainHandler(object):
             return
         self._data_manager.direct_beam_list.pop(index)
         self.ui.directBeamTable.removeRow(index)
-        self.main_window.initiate_reflectivity_or_intensity_plot.emit(False)
+        self.main_window.initiate_reflectivity_or_intensity_plot.emit()
 
     def clear_direct_beams(self):
         """Remove all items from the direct beam list."""
         self._data_manager.clear_direct_beam_list()
         self.ui.directBeamTable.setRowCount(0)
         self.ui.direct_beam_list_label.setText("None")
-        self.main_window.initiate_reflectivity_or_intensity_plot.emit(False)
+        self.main_window.initiate_reflectivity_or_intensity_plot.emit()
 
     def update_direct_beam_table(self, idx: int, data: CrossSectionData) -> None:
         """Update a direct beam table entry with cross-section data.
@@ -1100,7 +1100,7 @@ class MainHandler(object):
             )
 
         self.main_window.plotActiveTab()
-        self.main_window.initiate_reflectivity_or_intensity_plot.emit(True)
+        self.main_window.initiate_reflectivity_or_intensity_plot.emit()
         self.main_window.initiate_projection_plot.emit(True)
 
     def active_data_changed(self):
@@ -1621,7 +1621,7 @@ class MainHandler(object):
                     i, 1, QtWidgets.QTableWidgetItem("%.4f" % (d.configuration.scaling_factor))
                 )
 
-            self.main_window.initiate_reflectivity_or_intensity_plot.emit(False)
+            self.main_window.initiate_reflectivity_or_intensity_plot.emit()
 
     def trim_data_to_normalization(self):
         """Cut the start and end of the active data set to 5% of its maximum intensity."""
@@ -1630,7 +1630,7 @@ class MainHandler(object):
             self.ui.rangeStart.setValue(trim_points[0])
             self.ui.rangeEnd.setValue(trim_points[1])
             self.update_tables()
-            self.main_window.initiate_reflectivity_or_intensity_plot.emit(False)
+            self.main_window.initiate_reflectivity_or_intensity_plot.emit()
         else:
             self.report_message("No direct beam found to trim data", pop_up=False)
 
@@ -1643,7 +1643,7 @@ class MainHandler(object):
             d = self._data_manager.reduction_list[i].cross_sections[xs]
             self.reduction_table.setItem(i, 3, QtWidgets.QTableWidgetItem(str(d.configuration.cut_last_n_points)))
 
-        self.main_window.initiate_reflectivity_or_intensity_plot.emit(False)
+        self.main_window.initiate_reflectivity_or_intensity_plot.emit()
 
     def reload_all_files(self):
         """Reload all files upon change in loading configuration.

--- a/src/quicknxs/interfaces/main_window.py
+++ b/src/quicknxs/interfaces/main_window.py
@@ -27,11 +27,8 @@ class MainWindow(QtWidgets.QMainWindow):
     initiate_projection_plot = QtCore.Signal(bool)
     """Signal to initiate the projection plot."""
 
-    initiate_reflectivity_plot = QtCore.Signal(bool)
+    initiate_reflectivity_or_intensity_plot = QtCore.Signal(bool)
     """Signal to initiate the reflectivity plot."""
-
-    initiate_intensity_plot = QtCore.Signal(bool)
-    """Signal to initiate the intensity plot."""
 
     update_specular_viewer = QtCore.Signal()
     """Signal to update the specular viewer."""
@@ -85,8 +82,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.file_loaded_signal.connect(self.plotActiveTab)
 
         self.initiate_projection_plot.connect(self.plot_manager.plot_projections)
-        self.initiate_reflectivity_plot.connect(self.plot_manager.plot_refl)
-        self.initiate_intensity_plot.connect(self.plot_manager.plot_intensity)
+        self.initiate_reflectivity_or_intensity_plot.connect(self.plot_manager.plot_reflectivity_or_intensity)
 
         self.ui.deadtime_entry.settingsButton.clicked.connect(self.open_deadtime_settings)
         self.ui.deadtime_entry.reload_files_signal.connect(self.reload_all_files)
@@ -257,7 +253,8 @@ class MainWindow(QtWidgets.QMainWindow):
         self.plotActiveTab()
 
         if self.data_manager.active_cross_section.is_direct_beam:
-            self.initiate_intensity_plot.emit(False)
+            # Update the intensity plot in case the scale was toggled between ToF and Wavelength
+            self.initiate_reflectivity_or_intensity_plot.emit(False)
 
     def changeRegionValues(self):
         """Called when the reflectivity extraction region has been changed.
@@ -288,10 +285,7 @@ class MainWindow(QtWidgets.QMainWindow):
                     except Exception:
                         self.file_handler.report_message("There was a problem updating the reflectivity", pop_up=False)
                         logging.error("There was a problem updating the reflectivity")
-                if self.data_manager.active_cross_section.is_direct_beam:
-                    self.plot_manager.plot_intensity()
-                else:
-                    self.plot_manager.plot_refl()
+                self.plot_manager.plot_reflectivity_or_intensity()
                 self.update_specular_viewer.emit()
 
     def global_reflectivity_config_changed(self):
@@ -300,7 +294,7 @@ class MainWindow(QtWidgets.QMainWindow):
             return
 
         self.data_manager.reduce_spec()
-        self.initiate_reflectivity_plot.emit(True)
+        self.initiate_reflectivity_or_intensity_plot.emit(True)
         self.update_specular_viewer.emit()
 
     def reductionTableChanged(self, item):
@@ -332,10 +326,7 @@ class MainWindow(QtWidgets.QMainWindow):
     def replotProjections(self):
         """Signal handling to replot the projections."""
         self.initiate_projection_plot.emit(True)
-        if self.data_manager.active_cross_section.is_direct_beam:
-            self.initiate_intensity_plot.emit(True)
-        else:
-            self.initiate_reflectivity_plot.emit(True)
+        self.initiate_reflectivity_or_intensity_plot.emit(True)
 
     def addRefl(self):
         """Signal handling to add a new reflectivity data set."""
@@ -386,10 +377,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.file_handler.report_message("There was a problem updating the reflectivity", pop_up=False)
                 logging.error("There was a problem updating the reflectivity")
 
-            if self.data_manager.active_cross_section.is_direct_beam:
-                self.initiate_intensity_plot.emit(True)
-            else:
-                self.initiate_reflectivity_plot.emit(True)
+            self.initiate_reflectivity_or_intensity_plot.emit(True)
 
     def openByNumber(self):
         """Signal handling to open a file by run number."""

--- a/src/quicknxs/interfaces/main_window.py
+++ b/src/quicknxs/interfaces/main_window.py
@@ -27,8 +27,8 @@ class MainWindow(QtWidgets.QMainWindow):
     initiate_projection_plot = QtCore.Signal(bool)
     """Signal to initiate the projection plot."""
 
-    initiate_reflectivity_or_intensity_plot = QtCore.Signal(bool)
-    """Signal to initiate the reflectivity plot."""
+    initiate_reflectivity_or_intensity_plot = QtCore.Signal()
+    """Signal to initiate the reflectivity or intensity plot."""
 
     update_specular_viewer = QtCore.Signal()
     """Signal to update the specular viewer."""
@@ -254,7 +254,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         if self.data_manager.active_cross_section.is_direct_beam:
             # Update the intensity plot in case the scale was toggled between ToF and Wavelength
-            self.initiate_reflectivity_or_intensity_plot.emit(False)
+            self.initiate_reflectivity_or_intensity_plot.emit()
 
     def changeRegionValues(self):
         """Called when the reflectivity extraction region has been changed.
@@ -285,7 +285,7 @@ class MainWindow(QtWidgets.QMainWindow):
                     except Exception:
                         self.file_handler.report_message("There was a problem updating the reflectivity", pop_up=False)
                         logging.error("There was a problem updating the reflectivity")
-                self.plot_manager.plot_reflectivity_or_intensity()
+                self.initiate_reflectivity_or_intensity_plot.emit()
                 self.update_specular_viewer.emit()
 
     def global_reflectivity_config_changed(self):
@@ -294,7 +294,7 @@ class MainWindow(QtWidgets.QMainWindow):
             return
 
         self.data_manager.reduce_spec()
-        self.initiate_reflectivity_or_intensity_plot.emit(True)
+        self.initiate_reflectivity_or_intensity_plot.emit()
         self.update_specular_viewer.emit()
 
     def reductionTableChanged(self, item):
@@ -326,7 +326,7 @@ class MainWindow(QtWidgets.QMainWindow):
     def replotProjections(self):
         """Signal handling to replot the projections."""
         self.initiate_projection_plot.emit(True)
-        self.initiate_reflectivity_or_intensity_plot.emit(True)
+        self.initiate_reflectivity_or_intensity_plot.emit()
 
     def addRefl(self):
         """Signal handling to add a new reflectivity data set."""
@@ -377,7 +377,7 @@ class MainWindow(QtWidgets.QMainWindow):
                 self.file_handler.report_message("There was a problem updating the reflectivity", pop_up=False)
                 logging.error("There was a problem updating the reflectivity")
 
-            self.initiate_reflectivity_or_intensity_plot.emit(True)
+            self.initiate_reflectivity_or_intensity_plot.emit()
 
     def openByNumber(self):
         """Signal handling to open a file by run number."""

--- a/src/quicknxs/interfaces/plotting.py
+++ b/src/quicknxs/interfaces/plotting.py
@@ -594,7 +594,7 @@ class PlotManager(object):
             self.main_window.ui.refl.set_xlabel("$\\lambda{}$ [Å]")
         else:
             # convert raw microsecond units to milliseconds to match xtof plot
-            tof_ms = tof_ms = self.main_window.data_manager.active_cross_section.get_tof_counts_table()[0][:, 0] / 1000
+            tof_ms = self.main_window.data_manager.active_cross_section.get_tof_counts_table()[0][:, 0] / 1000
 
             self.main_window.ui.refl.errorbar(
                 tof_ms,
@@ -624,11 +624,14 @@ class PlotManager(object):
             return False
 
         if self.main_window.data_manager.active_cross_section.is_direct_beam:
+            plot_title = "Intensity"
             is_plotted = self._prepare_intensity_plot()
         else:
+            plot_title = "Reflectivity"
             is_plotted = self._prepare_reflectivity_plot()
 
         if is_plotted is not False:
+            # draw plot
             if self.main_window.ui.logarithmic_y.isChecked():
                 self.main_window.ui.refl.set_yscale("log")
             else:
@@ -636,6 +639,9 @@ class PlotManager(object):
             self.main_window.ui.refl.legend()
             self.main_window.ui.refl.toolbar.set_history_buttons()
             self.main_window.ui.refl.draw()
+
+            # update plot title
+            self.main_window.ui.reflectivity_or_intensity_plot_title.setText(plot_title)
 
             self.main_window.ui.compare_widget.update_preview()
 
@@ -709,6 +715,7 @@ class PlotManager(object):
             )
         self.main_window.ui.refl.canvas.ax.set_ylim((ymin * 0.9, ymax * 1.1))
         self.main_window.ui.refl.set_xlabel("Q$_z$ [Å$^{-1}$]")
+        return True
 
     def plot_gisans(self):
         """Create GISANS plots of the current dataset with Qy-Qz maps."""

--- a/src/quicknxs/interfaces/plotting.py
+++ b/src/quicknxs/interfaces/plotting.py
@@ -579,7 +579,12 @@ class PlotManager(object):
         widget.draw()
 
     def _prepare_intensity_plot(self):
-        """Add the direct beam intensity from the current dataset to the reflectivity/intensity plot."""
+        """Add the direct beam intensity from the current dataset to the reflectivity/intensity plot.
+
+        Returns
+        -------
+            True if the plot preparation was successful
+        """
         # format and plot tof data
 
         counts_normalized = self.main_window.data_manager.active_cross_section.get_tof_counts_table()[0][:, 2]
@@ -605,6 +610,9 @@ class PlotManager(object):
 
         # y-label is counts in either case
         self.main_window.ui.refl.set_ylabel("Normalized ROI Counts")
+
+        # plot prepared OK
+        return True
 
     def plot_reflectivity_or_intensity(self):
         """Plot reflectivity data or intensity, depending on the type of the active run.
@@ -648,7 +656,12 @@ class PlotManager(object):
         return is_plotted
 
     def _prepare_reflectivity_plot(self):
-        """Add the reflectivity from the current dataset and any dataset stored to the reflectivity/intensity plot."""
+        """Add the reflectivity from the current dataset and any dataset stored to the reflectivity/intensity plot.
+
+        Returns
+        -------
+            True if the plot preparation was successful, False otherwise
+        """
         if (
             self.main_window.data_manager.active_cross_section.r is None
             or self.main_window.data_manager.active_cross_section.q is None

--- a/src/quicknxs/interfaces/plotting.py
+++ b/src/quicknxs/interfaces/plotting.py
@@ -578,59 +578,73 @@ class PlotManager(object):
         )
         widget.draw()
 
-    def plot_intensity(self, preserve_lim=False):
-        """Calculate and display the direct beam intensity from the current dataset."""
-        # hide the reflectivity plot or clear existing intensity plot
-        self.main_window.ui.refl_widget.hide()
-        self.main_window.ui.intensity.clear()
-
-        if self.main_window.data_manager.active_cross_section is None:
-            self._plot_message(self.main_window.ui.intensity, "No data")
-            return False
-
+    def _prepare_intensity_plot(self):
+        """Add the direct beam intensity from the current dataset to the reflectivity/intensity plot."""
         # format and plot tof data
 
         counts_normalized = self.main_window.data_manager.active_cross_section.get_tof_counts_table()[0][:, 2]
         counts_normalized_error = self.main_window.data_manager.active_cross_section.get_tof_counts_table()[0][:, 3]
 
         if self.main_window.ui.xLamda.isChecked():
-            self.main_window.ui.intensity.errorbar(
+            self.main_window.ui.refl.errorbar(
                 self.main_window.data_manager.active_cross_section.wavelength,
                 counts_normalized,
                 yerr=counts_normalized_error,
             )
-            self.main_window.ui.intensity.set_xlabel("$\\lambda{}$ [Å]")
+            self.main_window.ui.refl.set_xlabel("$\\lambda{}$ [Å]")
         else:
             # convert raw microsecond units to milliseconds to match xtof plot
             tof_ms = tof_ms = self.main_window.data_manager.active_cross_section.get_tof_counts_table()[0][:, 0] / 1000
 
-            self.main_window.ui.intensity.errorbar(
+            self.main_window.ui.refl.errorbar(
                 tof_ms,
                 counts_normalized,
                 yerr=counts_normalized_error,
             )
-            self.main_window.ui.intensity.set_xlabel("ToF [ms]")
+            self.main_window.ui.refl.set_xlabel("ToF [ms]")
 
         # y-label is counts in either case
-        self.main_window.ui.intensity.set_ylabel("Normalized ROI Counts")
+        self.main_window.ui.refl.set_ylabel("Normalized ROI Counts")
 
-        # draw and show
-        self.main_window.ui.intensity.draw()
-        self.main_window.ui.intensity_widget.show()
+    def plot_reflectivity_or_intensity(self):
+        """Plot reflectivity data or intensity, depending on the type of the active run.
 
-    def plot_refl(self, preserve_lim=False):
-        """Plot reflectivity data.
+        If the active run is a direct beam run, the intensity vs ToF (or wavelength) in the
+        region-of-interest (ROI) is plotted.
+        Otherwise, the reflectivity of all datasets is plotted.
 
-        Calculate and display the reflectivity from the current dataset
-        and any dataset stored. Intensities from direct beam
-        measurements can be used for normalization.
+        Returns
+        -------
+            True if the plot was successful, False otherwise
         """
-        self.main_window.ui.intensity_widget.hide()
         self.main_window.ui.refl.clear()
 
+        if self.main_window.data_manager.active_cross_section is None:
+            self._plot_message(self.main_window.ui.refl, "No data")
+            return False
+
+        if self.main_window.data_manager.active_cross_section.is_direct_beam:
+            is_plotted = self._prepare_intensity_plot()
+        else:
+            is_plotted = self._prepare_reflectivity_plot()
+
+        if is_plotted is not False:
+            if self.main_window.ui.logarithmic_y.isChecked():
+                self.main_window.ui.refl.set_yscale("log")
+            else:
+                self.main_window.ui.refl.set_yscale("linear")
+            self.main_window.ui.refl.legend()
+            self.main_window.ui.refl.toolbar.set_history_buttons()
+            self.main_window.ui.refl.draw()
+
+            self.main_window.ui.compare_widget.update_preview()
+
+        return is_plotted
+
+    def _prepare_reflectivity_plot(self):
+        """Add the reflectivity from the current dataset and any dataset stored to the reflectivity/intensity plot."""
         if (
-            self.main_window.data_manager.active_cross_section is None
-            or self.main_window.data_manager.active_cross_section.r is None
+            self.main_window.data_manager.active_cross_section.r is None
             or self.main_window.data_manager.active_cross_section.q is None
             or self.main_window.data_manager.active_cross_section.dr is None
         ):
@@ -695,18 +709,6 @@ class PlotManager(object):
             )
         self.main_window.ui.refl.canvas.ax.set_ylim((ymin * 0.9, ymax * 1.1))
         self.main_window.ui.refl.set_xlabel("Q$_z$ [Å$^{-1}$]")
-
-        if self.main_window.ui.logarithmic_y.isChecked():
-            self.main_window.ui.refl.set_yscale("log")
-        else:
-            self.main_window.ui.refl.set_yscale("linear")
-        self.main_window.ui.refl.legend()
-        self.main_window.ui.refl.toolbar.set_history_buttons()
-        self.main_window.ui.refl.draw()
-
-        self.main_window.ui.refl_widget.show()
-
-        self.main_window.ui.compare_widget.update_preview()
 
     def plot_gisans(self):
         """Create GISANS plots of the current dataset with Qy-Qz maps."""

--- a/src/quicknxs/interfaces/plotting.py
+++ b/src/quicknxs/interfaces/plotting.py
@@ -579,12 +579,7 @@ class PlotManager(object):
         widget.draw()
 
     def _prepare_intensity_plot(self):
-        """Add the direct beam intensity from the current dataset to the reflectivity/intensity plot.
-
-        Returns
-        -------
-            True if the plot preparation was successful
-        """
+        """Add the direct beam intensity from the current dataset to the reflectivity/intensity plot."""
         # format and plot tof data
 
         counts_normalized = self.main_window.data_manager.active_cross_section.get_tof_counts_table()[0][:, 2]
@@ -611,9 +606,6 @@ class PlotManager(object):
         # y-label is counts in either case
         self.main_window.ui.refl.set_ylabel("Normalized ROI Counts")
 
-        # plot prepared OK
-        return True
-
     def plot_reflectivity_or_intensity(self):
         """Plot reflectivity data or intensity, depending on the type of the active run.
 
@@ -633,12 +625,13 @@ class PlotManager(object):
 
         if self.main_window.data_manager.active_cross_section.is_direct_beam:
             plot_title = "Intensity"
-            is_plotted = self._prepare_intensity_plot()
+            self._prepare_intensity_plot()
+            is_plotted = True
         else:
             plot_title = "Reflectivity"
             is_plotted = self._prepare_reflectivity_plot()
 
-        if is_plotted is not False:
+        if is_plotted:
             # draw plot
             if self.main_window.ui.logarithmic_y.isChecked():
                 self.main_window.ui.refl.set_yscale("log")

--- a/src/quicknxs/ui/ui_main_window.ui
+++ b/src/quicknxs/ui/ui_main_window.ui
@@ -5225,7 +5225,7 @@
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_22">
             <item>
-             <widget class="QLabel" name="label_33">
+             <widget class="QLabel" name="reflectivity_or_intensity_plot_title">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
                 <horstretch>0</horstretch>

--- a/src/quicknxs/ui/ui_main_window.ui
+++ b/src/quicknxs/ui/ui_main_window.ui
@@ -5258,51 +5258,6 @@
             </item>
            </layout>
           </widget>
-          <widget class="QWidget" name="intensity_widget" native="true">
-           <property name="visible">
-            <bool>false</bool>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>0</width>
-             <height>0</height>
-            </size>
-           </property>
-           <layout class="QVBoxLayout" name="verticalLayout_26">
-            <item>
-             <widget class="QLabel" name="label_56">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>Intensity</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignCenter</set>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="MPLWidget" name="intensity" native="true">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>150</width>
-                <height>150</height>
-               </size>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </widget>
          </widget>
         </item>
        </layout>
@@ -7459,8 +7414,6 @@
   <slot>open_polarization_window()</slot>
   <slot>open_rawdata_dialog()</slot>
   <slot>openByNumber()</slot>
-  <slot>plot_intensity()</slot>
-  <slot>plot_refl()</slot>
   <slot>plotActiveTab()</slot>
   <slot>prevFile()</slot>
   <slot>raiseError()</slot>

--- a/test/ui/test_main_window.py
+++ b/test/ui/test_main_window.py
@@ -34,7 +34,7 @@ class TestMainGui:
         """Test that selecting a cross-section radio button updates the active cross section."""
         # mock updating the plots
         mocker.patch("quicknxs.interfaces.main_window.MainWindow.plotActiveTab", return_value=True)
-        mocker.patch("quicknxs.interfaces.plotting.PlotManager.plot_refl", return_value=True)
+        mocker.patch("quicknxs.interfaces.plotting.PlotManager.plot_reflectivity_or_intensity", return_value=True)
         mocker.patch("quicknxs.interfaces.plotting.PlotManager.plot_projections", return_value=True)
 
         # create the SUT
@@ -87,7 +87,7 @@ class TestMainGui:
         """Test the global vs per run reduction variables."""
         # mock updating the plots
         mocker.patch("quicknxs.interfaces.main_window.MainWindow.plotActiveTab", return_value=True)
-        mocker.patch("quicknxs.interfaces.plotting.PlotManager.plot_refl", return_value=True)
+        mocker.patch("quicknxs.interfaces.plotting.PlotManager.plot_reflectivity_or_intensity", return_value=True)
         mocker.patch("quicknxs.interfaces.plotting.PlotManager.plot_projections", return_value=True)
 
         window_main = MainWindow()
@@ -308,7 +308,9 @@ class TestMainGui:
     @pytest.mark.datarepo
     def test_change_active_data_tab(self, mocker, qtbot, data_server):
         """Test that the internal state is updated when the active data tab is changed."""
-        mock_plot_refl = mocker.patch("quicknxs.interfaces.plotting.PlotManager.plot_refl", return_value=True)
+        mock_plot_refl = mocker.patch(
+            "quicknxs.interfaces.plotting.PlotManager.plot_reflectivity_or_intensity", return_value=True
+        )
 
         window_main = MainWindow()
         qtbot.addWidget(window_main)

--- a/test/ui/test_missing_cross_section.py
+++ b/test/ui/test_missing_cross_section.py
@@ -28,7 +28,7 @@ def test_missing_cross_section(qtbot):
     # select the On-On spin combination
     main_window.selectedCrossSection1.click()
     # check that counts is < 1 for entire tof
-    assert np.max(ui_utilities.data_from_plot1D(main_window.intensity)[1]) < 1
+    assert np.max(ui_utilities.data_from_plot1D(main_window.refl)[1]) < 1
     # check the x vs TOF plot has changed
     intensity_on_on = np.sum(ui_utilities.data_from_plot2D(main_window.xtof_overview))
     assert intensity_on_on / intensity_off_on < TEST_REFLECTIVITY_THRESHOLD_VALUE

--- a/test/ui/test_plotting.py
+++ b/test/ui/test_plotting.py
@@ -1,0 +1,36 @@
+import pytest
+
+from quicknxs.interfaces.main_window import MainWindow
+from test.ui import ui_utilities
+
+
+def _populate_reduction_and_direct_beam_tables(main_window):
+    # load file list
+    ui_utilities.setText(main_window.numberSearchEntry, str(42100), press_enter=True)
+
+    # select run in the file list
+    ui_utilities.set_current_file_by_run_number(main_window, 42100)
+    # add run to direct beams
+    main_window.actionAddDirectBeam.triggered.emit()
+
+    ui_utilities.set_current_file_by_run_number(main_window, 42112)
+    main_window.actionAddRefl.triggered.emit()
+
+    ui_utilities.set_current_file_by_run_number(main_window, 42113)
+    main_window.actionAddRefl.triggered.emit()
+
+
+@pytest.mark.datarepo
+def test_plot_reflectivity_or_intensity(qtbot):
+    """Test that the plot title is updated depending on the type of the active run."""
+    main_window = MainWindow()
+    qtbot.addWidget(main_window)
+    _populate_reduction_and_direct_beam_tables(main_window)
+
+    # select a sample run
+    main_window.reduction_cell_activated(0, 0)
+    assert main_window.ui.reflectivity_or_intensity_plot_title.text() == "Reflectivity"
+
+    # select a direct beam run
+    main_window.direct_beam_cell_activated(0, 0)
+    assert main_window.ui.reflectivity_or_intensity_plot_title.text() == "Intensity"


### PR DESCRIPTION
## Description of work:

The reflectivity plots and intensity plots were plotted in two different widgets in the same location and depending on the active run (direct beam or sample run), either the reflectivity or intensity widget was shown/hidden. We can simplify the logic, and eliminate the handling of which widget to show, by consolidating into one widget and choosing only what to plot in the widget depending on the active run.

Check all that apply:
- [ ] ~~updated documentation and checked that it looks correct in the [pull request preview]~~(https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [x] Source added/refactored
- [x] Added unit tests
- [ ] ~~Added integration tests~~

**References:**
- Links to IBM EWM items: [Defect 11665: [QuickNXS] Clicking "Final Rebin" causes the Reflectivity plot to disappear when a direct-beam is highlighted](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=11665)
- Links to related issues or pull requests:


# :warning: Manual test for the reviewer
([instructions to set up the environment](https://reflectivity-ui.readthedocs.io/en/latest/developer/environment.html))

1. Load some direct beam and sample runs and add to the direct beam and reduction tables, respectively. Double click on different run numbers in the tables to plot them and verify that the intensity/reflectivity plot is updated as expected.
2. Verify that the defect described in EWM 11665 is fixed.

# Check list for the reviewer
- [ ] [release notes](https://reflectivity-ui.readthedocs.io/en/latest/releasenotes/index.html) updated,
or an explanation is provided as to why release notes are unnecessary
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date and looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] code comments added when explaining intent
