### PR TITLE
Pip audit config

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -4022,8 +4022,8 @@ packages:
   timestamp: 1743692373820
 - pypi: ./
   name: quicknxs
-  version: 4.9.0rc3
-  sha256: 76687f933a40a2a1dabd035b39543d9bd0432a3dfc128e57784b5d241198cc70
+  version: 4.10.0.dev1
+  sha256: 9712cf50522320ff10963b6eaa8edfc433d7df9796ae19d2f8a0d8af3d3b6676
   requires_python: '>=3.10,<3.13'
   editable: true
 - conda: https://conda.anaconda.org/conda-forge/linux-64/rapidjson-1.1.0.post20240409-h3f2d84a_2.conda

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,7 +170,7 @@ conda-publish = { cmd = "anaconda upload *.conda", description = "Publish the .c
 ] }
 # Misc
 # ignore pillow error because it is only used by anaconda-client v1.13.0
-audit-deps = { cmd = "pip-audit --local --ignore-vuln=PYSEC-2025-61 --ignore-vuln=GHSA-xqrq-4mgf-ff32", description = "Audit the package dependencies for vulnerabilities" }
+audit-deps = { cmd = "pip-audit --local --ignore-vuln=GHSA-xqrq-4mgf-ff32", description = "Audit the package dependencies for vulnerabilities" }
 clean = { cmd = 'rm -rf .pytest_cache .ruff_cache **/*.egg-info **/dist **/__pycache__ **/_version.py', description = "Clean up various caches and build artifacts" }
 clean-conda = { cmd = "rm -f *.conda", description = "Clean the local .conda build artifacts" }
 clean-docs = { cmd = "rm -rf docs/_build", description = "Clean up documentation build artifacts" }


### PR DESCRIPTION
## Description of work:

The CI step to execute `pip-audit` fails because of a recently [reported vulnerability](
https://github.com/advisories/GHSA-xqrq-4mgf-ff32) in the package `future`.

```
$ pip-audit --local --ignore-vuln=PYSEC-2025-61
Found 1 known vulnerability in 1 package
Name   Version ID                  Fix Versions
------ ------- ------------------- ------------
future 1.0.0   GHSA-xqrq-4mgf-ff32
```
This dependency comes from `mantid`:
```
$ pixi tree -i future

future 1.0.0 
└── seekpath 2.1.0 
    └── euphonic 1.4.4 
        └── mantid 6.13.1.1 
            └── mr_reduction 2.11.0 
```
This PR changes the call to `pip-audit` to ignore this vulnerability. Fixing the vulnerability by removing the dependency on `future` will be done separately.

Check all that apply:
(if not, provide an explanation in the work description)
- [ ] updated documentation and checked that it looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests

**References:**
- Links to IBM EWM items:
- Links to related issues or pull requests:


# :warning: Manual test for the reviewer
([instructions to set up the environment](https://reflectivity-ui.readthedocs.io/en/latest/developer/environment.html))

# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date and looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] code comments added when explaining intent
