### PR TITLE
Display warning when loading file with too few events

### DIFF
--- a/src/quicknxs/interfaces/data_handling/instrument.py
+++ b/src/quicknxs/interfaces/data_handling/instrument.py
@@ -172,6 +172,12 @@ def remove_low_event_workspaces(ws_list, nbr_events_cutoff):
     return pruned_list
 
 
+class InsufficientEventCountError(Exception):
+    """Exception raised when the number of events in the workspace is too low"""
+
+    pass
+
+
 class Instrument(object):
     """Instrument class. Holds the data handling that is unique to a specific instrument."""
 
@@ -268,6 +274,11 @@ class Instrument(object):
         -------
         List[EventWorkspace]
             List of cross-section workspaces
+
+        Raises
+        ------
+        InsufficientEventCountError
+            If the data file does not contain enough events
         """
         temp_ws_root_name = "".join(random.sample(string.ascii_letters, 12))  # random string of 12 characters
         use_slow_flipper_log = self.USE_SLOW_FLIPPER_LOG
@@ -314,6 +325,8 @@ class Instrument(object):
 
         # Remove workspaces with too few events
         _path_xs_list = remove_low_event_workspaces(_path_xs_list, configuration.nbr_events_min)
+        if len(_path_xs_list) == 0:
+            raise InsufficientEventCountError(f"Too few events in: {file_path}")
 
         # Dead-time correction only applies to post-epics data
         if configuration is not None and configuration.apply_deadtime and not is_pre_epics:
@@ -388,6 +401,11 @@ class Instrument(object):
         -------
         List[EventWorkspace]:
             A list of EventWorkspaces, one for each cross-section
+
+        Raises
+        ------
+        InsufficientEventCountError
+            If the data file does not contain enough events
         """
         fp_instance = FilePath(file_path)
         ws_root_name = fp_instance.run_numbers(string_representation="short")

--- a/src/quicknxs/interfaces/data_handling/instrument.py
+++ b/src/quicknxs/interfaces/data_handling/instrument.py
@@ -326,7 +326,9 @@ class Instrument(object):
         # Remove workspaces with too few events
         _path_xs_list = remove_low_event_workspaces(_path_xs_list, configuration.nbr_events_min)
         if len(_path_xs_list) == 0:
-            raise InsufficientEventCountError(f"Too few events in: {file_path}")
+            raise InsufficientEventCountError(
+                f"All cross-sections contain fewer than {configuration.nbr_events_min} events in: {file_path}"
+            )
 
         # Dead-time correction only applies to post-epics data
         if configuration is not None and configuration.apply_deadtime and not is_pre_epics:

--- a/src/quicknxs/interfaces/event_handlers/main_handler.py
+++ b/src/quicknxs/interfaces/event_handlers/main_handler.py
@@ -21,6 +21,7 @@ from quicknxs.interfaces.configuration import BinningType, Configuration
 from quicknxs.interfaces.data_handling.data_manipulation import NormalizeToUnityQCutoffError
 from quicknxs.interfaces.data_handling.data_set import CrossSectionData, NexusData
 from quicknxs.interfaces.data_handling.filepath import FilePath, RunNumbers
+from quicknxs.interfaces.data_handling.instrument import InsufficientEventCountError
 from quicknxs.interfaces.data_manager import DataManager
 from quicknxs.interfaces.enums import DirectBeamTableColumn, ReductionTableColumn
 from quicknxs.interfaces.event_handlers.progress_reporter import ProgressReporter
@@ -149,6 +150,7 @@ class MainHandler(object):
                 return
 
         t_0 = time.time()
+        prog = None
         self.main_window.auto_change_active = True
         try:
             self.report_message(f"Loading file(s) {file_path}")
@@ -156,14 +158,18 @@ class MainHandler(object):
             configuration = self.get_configuration()
             self._data_manager.load(file_path, configuration, force=force, progress=prog)
             self.report_message(f"Loaded file(s) {self._data_manager.current_file_name}")
-        except RuntimeError as run_err:
-            # FIXME - need to find out what kind of error it could have
+        except InsufficientEventCountError as run_err:
             self.report_message(
-                f"Error loading file(s) {self._data_manager.current_file_name} due to {run_err}",
+                f"Error loading file(s) {self._data_manager.current_file_name} due to:\n{run_err}",
                 detailed_message=str(traceback.format_exc()),
-                pop_up=False,
+                pop_up=True,
                 is_error=True,
             )
+            self.main_window.auto_change_active = False
+            # reset progress bar
+            if prog is not None:
+                prog.reset()
+            return
 
         if not silent:
             self.file_loaded()

--- a/src/quicknxs/interfaces/event_handlers/main_handler.py
+++ b/src/quicknxs/interfaces/event_handlers/main_handler.py
@@ -158,7 +158,7 @@ class MainHandler(object):
             configuration = self.get_configuration()
             self._data_manager.load(file_path, configuration, force=force, progress=prog)
             self.report_message(f"Loaded file(s) {self._data_manager.current_file_name}")
-        except InsufficientEventCountError as run_err:
+        except (RuntimeError, InsufficientEventCountError) as run_err:
             self.report_message(
                 f"Error loading file(s) {self._data_manager.current_file_name} due to:\n{run_err}",
                 detailed_message=str(traceback.format_exc()),

--- a/src/quicknxs/interfaces/event_handlers/progress_reporter.py
+++ b/src/quicknxs/interfaces/event_handlers/progress_reporter.py
@@ -87,3 +87,7 @@ class ProgressReporter(object):
         sub_task_progress = ProgressReporter(max_value, self.update)
         self.sub_tasks.append(sub_task_progress)
         return sub_task_progress
+
+    def reset(self):
+        """Reset the progress bar to show no progress"""
+        self.progress_bar.reset()

--- a/src/quicknxs/interfaces/event_handlers/progress_reporter.py
+++ b/src/quicknxs/interfaces/event_handlers/progress_reporter.py
@@ -90,4 +90,8 @@ class ProgressReporter(object):
 
     def reset(self):
         """Reset the progress bar to show no progress"""
-        self.progress_bar.reset()
+        self.value = 0
+        for st in self.sub_tasks:
+            st.value = 0
+        if self.progress_bar is not None:
+            self.progress_bar.reset()

--- a/src/quicknxs/interfaces/main_window.py
+++ b/src/quicknxs/interfaces/main_window.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
 import os
+from contextlib import contextmanager
 
 from qtpy import QtCore, QtWidgets
 
@@ -15,6 +16,15 @@ from quicknxs.interfaces.plotting import PlotManager
 from quicknxs.interfaces.reduction_dialog import ReductionDialog
 from quicknxs.interfaces.smooth_dialog import SmoothDialog
 from quicknxs.ui.deadtime_settings import DeadTimeSettingsView
+
+
+@contextmanager
+def disabled_widget(widget: QtWidgets):
+    widget.setEnabled(False)
+    try:
+        yield
+    finally:
+        widget.setEnabled(True)
 
 
 class MainWindow(QtWidgets.QMainWindow):
@@ -171,7 +181,10 @@ class MainWindow(QtWidgets.QMainWindow):
         item = self.ui.file_list.currentItem()  # type: QListWidgetItem
         name = str(item.text())  # e.g 'REF_M_38199.nxs.h5' or 'REF_M_38198.nxs.h5+REF_M_38199.nxs.h5'
         filepath = FilePath.join(self.data_manager.current_directory, name)
-        self.file_handler.open_file(filepath)
+
+        # disable adding file to reduction or direct beam list before it has been successfully loaded
+        with disabled_widget(self.ui.mainToolbar):
+            self.file_handler.open_file(filepath)
 
     def reload_file(self):
         """Reload the file that is currently selected form the list."""

--- a/src/quicknxs/interfaces/main_window.py
+++ b/src/quicknxs/interfaces/main_window.py
@@ -19,12 +19,18 @@ from quicknxs.ui.deadtime_settings import DeadTimeSettingsView
 
 
 @contextmanager
-def disabled_widget(widget: QtWidgets):
+def disabled_widget(widget: QtWidgets.QWidget):
+    """
+    Temporarily disable a widget for the duration of the context.
+
+    Restores the enabled state of the widget when the context exits.
+    """
+    prev_enabled = widget.isEnabled()
     widget.setEnabled(False)
     try:
         yield
     finally:
-        widget.setEnabled(True)
+        widget.setEnabled(prev_enabled)
 
 
 class MainWindow(QtWidgets.QMainWindow):

--- a/test/ui/test_main_window.py
+++ b/test/ui/test_main_window.py
@@ -3,7 +3,7 @@ from qtpy import QtCore, QtWidgets
 
 from quicknxs.interfaces.configuration import BinningType, Configuration
 from quicknxs.interfaces.data_handling.data_set import CrossSectionData, NexusData
-from quicknxs.interfaces.main_window import MainWindow
+from quicknxs.interfaces.main_window import MainWindow, disabled_widget
 from test.ui import ui_utilities
 
 
@@ -420,6 +420,30 @@ class TestMainGui:
         # check that the run was removed from the tables
         assert len(window_main.data_manager.reduction_list) == 0
         assert len(window_main.data_manager.direct_beam_list) == 0
+
+    def test_disabled_widget_enabled(self, qtbot):
+        """Test context manager disabled_widget"""
+        window_main = MainWindow()
+        qtbot.addWidget(window_main)
+        widget = window_main.ui.mainToolbar
+
+        with disabled_widget(widget):
+            assert not widget.isEnabled()
+
+        assert widget.isEnabled()
+
+    def test_disabled_widget_enabled_after_exception(self, qtbot):
+        """Test context manager disabled_widget"""
+        window_main = MainWindow()
+        qtbot.addWidget(window_main)
+        widget = window_main.ui.mainToolbar
+
+        with pytest.raises(ValueError):
+            with disabled_widget(widget):
+                assert not widget.isEnabled()
+                raise ValueError("bad value")
+
+        assert widget.isEnabled()
 
 
 if __name__ == "__main__":

--- a/test/ui/test_main_window.py
+++ b/test/ui/test_main_window.py
@@ -421,8 +421,12 @@ class TestMainGui:
         assert len(window_main.data_manager.reduction_list) == 0
         assert len(window_main.data_manager.direct_beam_list) == 0
 
-    def test_disabled_widget_enabled(self, qtbot):
-        """Test context manager disabled_widget"""
+
+class TestDisabledWidget:
+    """Tests for the disabled_widget context manager."""
+
+    def test_enabled_widget_reenabled(self, qtbot):
+        """Test that an enabled widget is disabled inside the context and enabled after the context."""
         window_main = MainWindow()
         qtbot.addWidget(window_main)
         widget = window_main.ui.mainToolbar
@@ -432,8 +436,20 @@ class TestMainGui:
 
         assert widget.isEnabled()
 
+    def test_disabled_widget_redisabled(self, qtbot):
+        """Test that a disabled widget is still disabled after the context."""
+        window_main = MainWindow()
+        qtbot.addWidget(window_main)
+        widget = window_main.ui.mainToolbar
+
+        widget.setEnabled(False)
+        with disabled_widget(widget):
+            assert not widget.isEnabled()
+
+        assert not widget.isEnabled()
+
     def test_disabled_widget_enabled_after_exception(self, qtbot):
-        """Test context manager disabled_widget"""
+        """Test that a widget is reenabled after an exception is raised inside the context."""
         window_main = MainWindow()
         qtbot.addWidget(window_main)
         widget = window_main.ui.mainToolbar
@@ -442,6 +458,20 @@ class TestMainGui:
             with disabled_widget(widget):
                 assert not widget.isEnabled()
                 raise ValueError("bad value")
+
+        assert widget.isEnabled()
+
+    def test_nested_contexts(self, qtbot):
+        """Test that nested contexts work as expected."""
+        window_main = MainWindow()
+        qtbot.addWidget(window_main)
+        widget = window_main.ui.mainToolbar
+
+        with disabled_widget(widget):
+            assert not widget.isEnabled()
+            with disabled_widget(widget):
+                assert not widget.isEnabled()
+            assert not widget.isEnabled()
 
         assert widget.isEnabled()
 

--- a/test/unit/quicknxs/interfaces/data_handling/test_instrument.py
+++ b/test/unit/quicknxs/interfaces/data_handling/test_instrument.py
@@ -7,7 +7,7 @@ from mantid.kernel import Direction
 from mantid.simpleapi import CreateSingleValuedWorkspace
 
 from quicknxs.interfaces.configuration import Configuration
-from quicknxs.interfaces.data_handling.instrument import mantid_algorithm_exec
+from quicknxs.interfaces.data_handling.instrument import InsufficientEventCountError, mantid_algorithm_exec
 
 
 @pytest.mark.datarepo
@@ -95,6 +95,18 @@ def test_load_data_nbr_events_min(data_server):
     conf.apply_deadtime = True
     ws_list = conf.instrument.load_data(file_path, conf)
     assert len(ws_list) == 2
+
+
+@pytest.mark.datarepo
+def test_load_data_insufficient_event_count(data_server):
+    """Test load data with too few events"""
+    Configuration.setup_default_values()
+
+    conf = Configuration()
+    file_path = data_server.path_to("REF_M_43670")
+
+    with pytest.raises(InsufficientEventCountError):
+        conf.instrument.load_data(file_path, conf)
 
 
 @pytest.mark.parametrize(

--- a/test/unit/quicknxs/interfaces/event_handlers/test_main_handler.py
+++ b/test/unit/quicknxs/interfaces/event_handlers/test_main_handler.py
@@ -14,6 +14,7 @@ from qtpy import QtCore, QtWidgets
 from quicknxs.interfaces.configuration import Configuration
 from quicknxs.interfaces.data_handling.data_manipulation import NormalizeToUnityQCutoffError
 from quicknxs.interfaces.data_handling.data_set import CrossSectionData, NexusData
+from quicknxs.interfaces.data_handling.instrument import InsufficientEventCountError
 from quicknxs.interfaces.event_handlers.main_handler import MainHandler
 from quicknxs.interfaces.main_window import MainWindow
 from test.ui import ui_utilities
@@ -255,6 +256,21 @@ def test_reduction_table(qtbot):
     assert handler.reduction_table == main_data_table_widget
     data_tab_widget.setCurrentIndex(2)
     assert handler.reduction_table == second_data_table_widget
+
+
+def test_open_file_insufficient_event_count_error(mocker, qtbot):
+    mocker.patch("quicknxs.interfaces.data_manager.DataManager.load", side_effect=InsufficientEventCountError)
+    mocker.patch("os.path.isfile", return_value=True)
+    mock_report_message = mocker.patch("quicknxs.interfaces.event_handlers.main_handler.MainHandler.report_message")
+
+    main_window = MainWindow()
+    qtbot.addWidget(main_window)
+    handler = MainHandler(main_window)
+
+    handler.open_file("test/file/path")
+
+    assert mock_report_message.call_count == 2
+    assert "Error loading file(s)" in mock_report_message.call_args[0][0]
 
 
 if __name__ == "__main__":

--- a/test/unit/quicknxs/interfaces/event_handlers/test_main_handler.py
+++ b/test/unit/quicknxs/interfaces/event_handlers/test_main_handler.py
@@ -258,8 +258,15 @@ def test_reduction_table(qtbot):
     assert handler.reduction_table == second_data_table_widget
 
 
-def test_open_file_insufficient_event_count_error(mocker, qtbot):
-    mocker.patch("quicknxs.interfaces.data_manager.DataManager.load", side_effect=InsufficientEventCountError)
+@pytest.mark.parametrize(
+    "error_type",
+    [
+        (InsufficientEventCountError),
+        (RuntimeError),
+    ],
+)
+def test_open_file_insufficient_event_count_error(error_type, mocker, qtbot):
+    mocker.patch("quicknxs.interfaces.data_manager.DataManager.load", side_effect=error_type)
     mocker.patch("os.path.isfile", return_value=True)
     mock_report_message = mocker.patch("quicknxs.interfaces.event_handlers.main_handler.MainHandler.report_message")
 


### PR DESCRIPTION
## Description of work:

The IS noticed that the GUI would freeze when loading a file with very few events. There was a filtering of cross-sections with less than 100 events and this bug occurred when all cross-sections were filtered out.

Changes:
- disable the buttons to add a run to the reduction or direct beam table while a file is loading
- raise a custom exception if all cross-sections are filtered out and display a warning pop up message to the user

Check all that apply:
(if not, provide an explanation in the work description)
- [ ] ~~updated documentation and checked that it looks correct in the [pull request preview]~~(https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [x] Source added/refactored
- [x] Added unit tests
- [ ] ~~Added integration tests~~

**References:**
- Links to IBM EWM items: [Defect 12237: [QuickNXS] Warning dialog for runs with insufficient number of events](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=12237)
- Links to related issues or pull requests:


# :warning: Manual test for the reviewer
([instructions to set up the environment](https://reflectivity-ui.readthedocs.io/en/latest/developer/environment.html))

Load new file in the data repo: `test/data/quicknxs-data/REF_M_43670.nxs.h5` and verify that you see the pop up message:

<img width="538" height="184" alt="image" src="https://github.com/user-attachments/assets/6496a130-ac78-4930-ad7b-297f3c905e7b" />

# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date and looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] code comments added when explaining intent
