### PR TITLE
Publish dev conda package

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -169,7 +169,6 @@ jobs:
           ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
           CONDA_LABEL: dev
         run: |
-          # label is main or rc depending on the tag-name
           echo pushing ${{ github.ref }} with label ${{ env.CONDA_LABEL}}
           pixi run anaconda upload --label ${{ env.CONDA_LABEL}} --user neutrons ${{ env.PKG_NAME }}-*.conda
 

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -144,7 +144,7 @@ jobs:
   publish-dev:
     runs-on: ubuntu-latest
     needs: [tests, build]
-    if: github.ref_name == 'publish_packages'
+    #if: github.ref == 'refs/heads/next'
     defaults:
       run:
         shell: bash -el {0}

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -144,7 +144,7 @@ jobs:
   publish-dev:
     runs-on: ubuntu-latest
     needs: [tests, build]
-    #if: github.ref == 'refs/heads/next'
+    if: github.ref == 'refs/heads/next'
     defaults:
       run:
         shell: bash -el {0}

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -110,7 +110,7 @@ jobs:
           path: ${{ env.PKG_NAME }}-*.conda
 
   publish:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     needs: [tests, build]
     if: startsWith(github.ref, 'refs/tags/v')
     defaults:
@@ -120,8 +120,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          fetch-depth: 100
-          fetch-tags: true
           ref: ${{ github.ref }}
 
       - name: Setup Pixi
@@ -143,10 +141,51 @@ jobs:
           echo pushing ${{ github.ref }} with label $CONDA_LABEL
           pixi run anaconda upload --label $CONDA_LABEL --user neutrons ${{ env.PKG_NAME }}-*.conda
 
+  publish-dev:
+    runs-on: ubuntu-latest
+    needs: [tests, build]
+    if: github.ref_name == 'publish_packages'
+    defaults:
+      run:
+        shell: bash -el {0}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Setup Pixi
+        uses: prefix-dev/setup-pixi@v0.9.4
+        with:
+          activate-environment: true
+
+      - name: Download conda package artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: artifact-conda-package
+
+      - name: Upload package to anaconda
+        env:
+          ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
+          CONDA_LABEL: dev
+        run: |
+          # label is main or rc depending on the tag-name
+          echo pushing ${{ github.ref }} with label ${{ env.CONDA_LABEL}}
+          pixi run anaconda upload --label ${{ env.CONDA_LABEL}} --user neutrons ${{ env.PKG_NAME }}-*.conda
+
+      - name: Remove old packages
+        uses: neutrons/conda-pkg-remove@v1.0
+        with:
+          anaconda_token: ${{ secrets.ANACONDA_TOKEN }}
+          organization: neutrons
+          package_name: quicknxs
+          label: ${{ env.CONDA_LABEL }}
+          keep: 5
+
   # Trigger GitLab dev deploy pipeline
   deploy-dev:
     runs-on: ubuntu-latest
-    needs: build
+    needs: [tests, build, publish-dev]
     if: github.ref == 'refs/heads/next'
     steps:
       - name: Get Environment Name


### PR DESCRIPTION
Add functionality to publish conda packages from development runs. This also cleans out old dev packages from anaconda.

## To test

You can see a working version on https://github.com/neutrons/quicknxs/pull/264/commits/05c064c38106385ad403098b048e779602698a5d with the result seen [here on anaconda/neutrons](https://anaconda.org/channels/neutrons/packages/quicknxs/labels)