### PR TITLE
Fix summing files when loading file both individually and as part of sum

### DIFF
--- a/src/quicknxs/interfaces/data_handling/instrument.py
+++ b/src/quicknxs/interfaces/data_handling/instrument.py
@@ -252,31 +252,34 @@ class Instrument(object):
         This function assumes that when loading more than one data file, the files are congruent and their
         events will be added together.
 
-        Args:
-            file_path (str): absolute path to one or more data files. If more than one, paths should be concatenated with the plus symbol '+'.
-            configuration (Configuration): reduction configuration parameters
+        Parameters
+        ----------
+        file_path:
+            Absolute path to one or more data files. If more than one, paths should be
+            concatenated with the plus symbol '+'.
+        configuration:
+            Reduction configuration parameters.
 
         Returns
         -------
-        List[EventWorkspace]:
-            A list of EventWorkspaces, one for each cross-section
+        list[EventWorkspace]:
+            A list of EventWorkspaces, one for each cross-section.
 
         Raises
         ------
         CrossSectionError
-            If the data file does not contain enough events
+            If the data file does not contain enough events.
         """
         fp_instance = FilePath(file_path)
-        ws_root_name = fp_instance.run_numbers(string_representation="short")
         ws_run_numbers = fp_instance.run_numbers(string_representation="long")
 
-        # Collect cross-sections from all files
+        # Collect cross-sections from all files, keyed by the per-file workspace root name
         all_xs_lists = []
+        path_ws_names = []
         try:
-            for idx, path in enumerate(fp_instance.single_paths):
-                # Use unique workspace names for each file to avoid overwrites
-                path_fp = FilePath(path)
-                path_ws_name = path_fp.run_numbers(string_representation="short")
+            for path in fp_instance.single_paths:
+                path_ws_name = FilePath(path).run_numbers(string_representation="short")
+                path_ws_names.append(path_ws_name)
                 all_xs_lists.append(self._get_xs_list(path, path_ws_name, configuration))
         except CrossSectionError as err:
             raise CrossSectionError(file_path, err.message, err.min_num_events) from err
@@ -285,17 +288,26 @@ class Instrument(object):
         if len(all_xs_lists) == 1:
             xs_list = all_xs_lists[0]
         else:
+            # Build a combined root name for the merged workspaces
+            # This prevents name clashes if the individual files are loaded as well
+            first_path_root = path_ws_names[0]
+            combined_root = ws_run_numbers.replace("+", "_")
+
             # Merge cross-sections from multiple files by matching cross_section_id
-            xs_list = all_xs_lists[0]
-            for i, ws in enumerate(xs_list):
-                # Merge workspaces with matching cross_section_id from subsequent files
+            xs_list = []
+            for i, ws in enumerate(all_xs_lists[0]):
+                # Derive the per-cross-section suffix from the first file's workspace name
+                # (e.g. "42112_Off_Off" -> suffix "_Off_Off")
+                suffix = str(ws)[len(first_path_root) :]
+                output_name = combined_root + suffix
+                merged = ws
                 for xs_group in all_xs_lists[1:]:
                     merged = api.Plus(
-                        LHSWorkspace=str(ws),
+                        LHSWorkspace=str(merged),
                         RHSWorkspace=str(xs_group[i]),
-                        OutputWorkspace=str(ws),
+                        OutputWorkspace=output_name,
                     )
-                    xs_list[i] = merged  # Update the reference to the merged workspace
+                xs_list.append(merged)
 
         # Insert a log indicating which run numbers contributed to this cross-section
         for ws in xs_list:

--- a/test/unit/quicknxs/interfaces/data_handling/test_instrument.py
+++ b/test/unit/quicknxs/interfaces/data_handling/test_instrument.py
@@ -124,6 +124,9 @@ def test_load_data_sum_two_files(data_server):
     ws_list_42113 = [str(ws) for ws in ws_obj_list_42113]
 
     # Verify events are summed correctly for each cross-section
+    # Note: the workspaces are compared by name as a regression test to a previous issue where the
+    # name of the merged workspace was the same as one of the individual files, however, the issue
+    # was not seen when comparing by workspace handle, only by name in the ADS.
     for i in range(4):
         expected_events = mtd[ws_list_42112[i]].getNumberEvents() + mtd[ws_list_42113[i]].getNumberEvents()
         actual_events = mtd[ws_list[i]].getNumberEvents()

--- a/test/unit/quicknxs/interfaces/data_handling/test_instrument.py
+++ b/test/unit/quicknxs/interfaces/data_handling/test_instrument.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 import pytest
+from mantid.simpleapi import mtd
 
 from quicknxs.interfaces.configuration import Configuration
 from quicknxs.interfaces.data_handling.instrument import CrossSectionError
@@ -102,13 +103,14 @@ def test_load_data_sum_two_files(data_server):
     # Use files 42112 and 42113 which are known to work individually
     file_path = data_server.path_to("REF_M_42112") + "+" + data_server.path_to("REF_M_42113")
 
-    ws_list = conf.instrument.load_data(file_path, conf)
+    ws_obj_list = conf.instrument.load_data(file_path, conf)
+    ws_list = [str(ws) for ws in ws_obj_list]
 
     # Should have 4 cross-sections (not 8 - that would indicate concatenation not merging)
-    assert len(ws_list) == 4, f"Expected 4 cross-sections, got {len(ws_list)}"
+    assert len(ws_obj_list) == 4, f"Expected 4 cross-sections, got {len(ws_obj_list)}"
 
     # Verify run_numbers property exists and is correct
-    for ws in ws_list:
+    for ws in ws_obj_list:
         run = ws.getRun()
         assert run.hasProperty("run_numbers"), "run_numbers property not found"
         run_numbers = run.getProperty("run_numbers").value
@@ -116,13 +118,15 @@ def test_load_data_sum_two_files(data_server):
 
     # Load individual files to compare event counts
     conf_single = Configuration()
-    ws_list_42112 = conf_single.instrument.load_data(data_server.path_to("REF_M_42112"), conf_single)
-    ws_list_42113 = conf_single.instrument.load_data(data_server.path_to("REF_M_42113"), conf_single)
+    ws_obj_list_42112 = conf_single.instrument.load_data(data_server.path_to("REF_M_42112"), conf_single)
+    ws_list_42112 = [str(ws) for ws in ws_obj_list_42112]
+    ws_obj_list_42113 = conf_single.instrument.load_data(data_server.path_to("REF_M_42113"), conf_single)
+    ws_list_42113 = [str(ws) for ws in ws_obj_list_42113]
 
     # Verify events are summed correctly for each cross-section
     for i in range(4):
-        expected_events = ws_list_42112[i].getNumberEvents() + ws_list_42113[i].getNumberEvents()
-        actual_events = ws_list[i].getNumberEvents()
+        expected_events = mtd[ws_list_42112[i]].getNumberEvents() + mtd[ws_list_42113[i]].getNumberEvents()
+        actual_events = mtd[ws_list[i]].getNumberEvents()
         assert actual_events == expected_events, (
             f"Cross-section {i}: expected {expected_events} events, got {actual_events}"
         )


### PR DESCRIPTION
## Description of work:

When loading a sum of multiple run files (e.g. REF_M_42112+REF_M_42113), the merged cross-section workspace were given names including the first file name only (e.g. 42112_On_Off). This meant that if the file individual file was subsequently loaded, Mantid's ADS would overwrite the merged workspace with the data from the individual file.

Merged workspaces now use a combined root file name formed from the contributing run numbers (e.g. 42112_42113_On_Off) to avoid name clashes if the individual files are loaded.

Check all that apply:
(if not, provide an explanation in the work description)
- [ ] updated documentation and checked that it looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] Source added/refactored
- [x] Added unit tests
- [ ] Added integration tests

**References:**
- Links to IBM EWM items: found during development of [Defect 14846: [QuickNXS] Mismatch in active run between file list and data tab](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=14846)
- Links to related issues or pull requests:


# :warning: Manual test for the reviewer
([instructions to set up the environment](https://reflectivity-ui.readthedocs.io/en/latest/developer/environment.html))

1. Load and sum two files with `File > Open & Sum Multiple Files` (e.g. 42112 + 42113) and add to the reduction table.
2. Load the runs individually and add them to the reduction table.
3. Verify by comparing the 2D plots and the reflectivity curve that the summed run is different from the individual runs.

<img width="463" height="273" alt="image" src="https://github.com/user-attachments/assets/42083257-b384-4cd0-bc40-7f41142eb214" />

# Check list for the reviewer
- [x] best software practices
    + [x] clearly named variables (better to be verbose in variable names)
    + [x] code comments explaining the intent of code blocks
- [x] All the tests are passing
- [x] The documentation is up to date and looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [x] code comments added when explaining intent
