### PR TITLE
Exclude rc tags when calculating versioningit distance

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -97,7 +97,7 @@ jobs:
         with:
           python-version: "3.11"
           local-channel: /tmp/local-channel
-          package-name: ${{ env.PKG_NAME }}=${{ env.PKG_VERSION }} # install exact version
+          package-name: ${{ env.PKG_NAME }}
           extra-channels: neutrons mantid oncat
           extra-commands: |
             python -c "import mr_reduction"

--- a/pixi.lock
+++ b/pixi.lock
@@ -9,6 +9,8 @@ environments:
     - url: https://prefix.dev/pixi-build-backends/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -4331,10 +4333,9 @@ packages:
   timestamp: 1743692373820
 - pypi: ./
   name: quicknxs
-  version: 4.17.0.dev19
-  sha256: 2c5b147bbbacc60665498bb801bd3ffc44efa175d5a98a1d48b6c90da013720d
+  version: 4.16.0.dev19
+  sha256: bc3379a515b7b22f99278a185603e257d5756d2eeeb909cd3c92386218521daf
   requires_python: '>=3.10,<3.13'
-  editable: true
 - conda: https://conda.anaconda.org/conda-forge/linux-64/rapidjson-1.1.0.post20240409-h3f2d84a_2.conda
   sha256: f87f265263a1ddbc50b98e2c2bcaa2bac63da3acc09267815dd0f4bd614cd902
   md5: 65e2f30d532b4ae2063a424c185cc678

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ packages = ["src/quicknxs"]
 [tool.versioningit.vcs]
 method = "git"
 default-tag = "4.0.0"
+exclude = ["*rc*"]
 
 [tool.versioningit.next-version]
 method = "minor"


### PR DESCRIPTION
## Description of work:

This fixes a problem with dev package version numbering being reset whenever a new RC was tagged. After this change, the number of commits should always be calculated from the latest prod version (as long as we don't create any tags other than for RC:s and prod versions).

Check all that apply:
(if not, provide an explanation in the work description)
- [ ] updated documentation and checked that it looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests

**References:**
- Links to IBM EWM items:
- Links to related issues or pull requests:


# :warning: Manual test for the reviewer
([instructions to set up the environment](https://reflectivity-ui.readthedocs.io/en/latest/developer/environment.html))

# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date and looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] code comments added when explaining intent
