### PR TITLE
fix(test): skip datarepo tests when Git LFS data is unavailable

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -21,6 +21,52 @@ pytest_plugins = ["mantid.fixtures"]
 
 this_module_path = sys.modules[__name__].__file__
 
+# Path to the LFS-backed test data submodule
+_QUICKNXS_DATA_DIR = Path(__file__).parent / "data" / "quicknxs-data"
+
+# LFS pointer files start with this signature
+_LFS_POINTER_SIGNATURE = b"version https://git-lfs.github.com/spec/v1"
+
+_SKIP_REASON = (
+    "Git LFS data not available. "
+    "Run 'git submodule update --init && cd test/data/quicknxs-data && git lfs pull' "
+    "to fetch test data files."
+)
+
+
+def _lfs_data_is_available():
+    """Check whether the LFS-backed test data files contain real data (not pointer stubs).
+
+    Returns True if the submodule directory exists and at least one .nxs.h5 file
+    is a real HDF5 file (not a ~130-byte LFS pointer stub).
+    """
+    if not _QUICKNXS_DATA_DIR.is_dir():
+        return False
+    sentinel = _QUICKNXS_DATA_DIR / "REF_M_42099.nxs.h5"
+    if not sentinel.exists():
+        return False
+    # LFS pointer stubs are small ASCII files (~130 bytes); real HDF5 files are megabytes
+    if sentinel.stat().st_size < 1024:
+        return False
+    # Double-check by reading the first bytes — LFS pointers start with a known signature
+    with open(sentinel, "rb") as fh:
+        header = fh.read(len(_LFS_POINTER_SIGNATURE))
+    return header != _LFS_POINTER_SIGNATURE
+
+
+# Evaluate once at import time so every fixture/hook can reuse the result
+_HAS_LFS_DATA = _lfs_data_is_available()
+
+
+def pytest_collection_modifyitems(config, items):
+    """Auto-skip tests marked with @pytest.mark.datarepo when LFS data is unavailable."""
+    if _HAS_LFS_DATA:
+        return
+    skip_marker = pytest.mark.skip(reason=_SKIP_REASON)
+    for item in items:
+        if "datarepo" in item.keywords:
+            item.add_marker(skip_marker)
+
 
 ################################################
 # FIXTURES AUTOMATICALLY APPLIED TO EVERY TEST #
@@ -56,6 +102,8 @@ Instrument.file_search_template = str(Path(__file__).parent / "data" / "quicknxs
 @pytest.fixture(scope="module")
 def data_server(DATA_DIR):
     r"""Object containing info and functionality for data files."""
+    if not _HAS_LFS_DATA:
+        pytest.skip(_SKIP_REASON)
 
     class _DataServe(object):
         _directory = str(DATA_DIR)


### PR DESCRIPTION
## Summary

- Adds a conftest guard that detects when the `test/data/quicknxs-data/` submodule contains Git LFS pointer stubs instead of real HDF5 data files
- Auto-skips all `@pytest.mark.datarepo` tests with a clear, actionable message telling the developer how to fetch the data
- Also guards the `data_server` fixture directly, catching tests that use it but lack the `datarepo` marker

## Motivation

Without this guard, if `git-lfs` is not installed or `git lfs pull` has not been run in the submodule, 68+ tests fail with unhelpful Mantid `NexusDescriptor couldn't open hdf5 file` or h5py `file signature not found` errors. The new guard provides an immediate, actionable skip message:

> Git LFS data not available. Run 'git submodule update --init && cd test/data/quicknxs-data && git lfs pull' to fetch test data files.

## How it works

1. `_lfs_data_is_available()` checks a sentinel file (`REF_M_42099.nxs.h5`) — verifies it exists, is >1 KB, and does not start with the LFS pointer signature
2. `pytest_collection_modifyitems()` adds a skip marker to all `datarepo`-marked tests when LFS data is unavailable
3. The `data_server` fixture calls `pytest.skip()` as a fallback for tests that use it without the marker

No behavior change when LFS data is present — all tests run normally.

## Test plan

- [x] Full test suite passes with LFS data present (246 passed, 2 pre-existing failures, 3 skipped)
- [x] Detection correctly identifies LFS pointer stubs (verified with synthetic pointer file)
- [x] Detection correctly identifies real HDF5 files
- [x] Detection handles missing submodule directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)