### PR TITLE
Define default values & increase decimal precision

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -9,8 +9,6 @@ environments:
     - url: https://prefix.dev/pixi-build-backends/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -4333,9 +4331,10 @@ packages:
   timestamp: 1743692373820
 - pypi: ./
   name: quicknxs
-  version: 4.16.0.dev19
+  version: 4.16.0.dev26
   sha256: bc3379a515b7b22f99278a185603e257d5756d2eeeb909cd3c92386218521daf
   requires_python: '>=3.10,<3.13'
+  editable: true
 - conda: https://conda.anaconda.org/conda-forge/linux-64/rapidjson-1.1.0.post20240409-h3f2d84a_2.conda
   sha256: f87f265263a1ddbc50b98e2c2bcaa2bac63da3acc09267815dd0f4bd614cd902
   md5: 65e2f30d532b4ae2063a424c185cc678

--- a/src/quicknxs/interfaces/data_handling/processing_workflow.py
+++ b/src/quicknxs/interfaces/data_handling/processing_workflow.py
@@ -49,6 +49,18 @@ DEFAULT_OPTIONS = dict(
     email_cc="",
     email_subject="",
     email_test="",
+    # Off-specular defaults (match Configuration defaults)
+    off_spec_x_axis=0,  # Configuration.DELTA_KZ_VS_QZ
+    off_spec_x_min=-0.015,
+    off_spec_x_max=0.015,
+    off_spec_y_min=0.0,
+    off_spec_y_max=0.15,
+    off_spec_nxbins=450,
+    off_spec_nybins=200,
+    off_spec_err_weight=False,
+    off_spec_sigmas=3,
+    off_spec_sigmax=0.0005,
+    off_spec_sigmay=0.0005,
     off_spec_slice_qz_min=0.05,
     off_spec_slice_qz_max=0.07,
 )
@@ -60,7 +72,10 @@ class ProcessingWorkflow(object):
     def __init__(self, data_manager: DataManager, output_options: Optional[dict] = None):
         """All the reduced data shall come from data manager."""
         self.data_manager = data_manager
-        self.output_options = output_options if output_options else DEFAULT_OPTIONS
+        # Merge defaults with provided options to ensure all required keys are present
+        self.output_options = DEFAULT_OPTIONS.copy()
+        if output_options:
+            self.output_options.update(output_options)
         self.exported_data_files = []
         self.exported_data_plots = []
 

--- a/src/quicknxs/interfaces/data_handling/processing_workflow.py
+++ b/src/quicknxs/interfaces/data_handling/processing_workflow.py
@@ -49,6 +49,8 @@ DEFAULT_OPTIONS = dict(
     email_cc="",
     email_subject="",
     email_test="",
+    off_spec_slice_qz_min=0.05,
+    off_spec_slice_qz_max=0.07,
 )
 
 

--- a/src/quicknxs/ui/ui_smooth_dialog.ui
+++ b/src/quicknxs/ui/ui_smooth_dialog.ui
@@ -109,7 +109,7 @@
              <string> 1/A</string>
             </property>
             <property name="decimals">
-             <number>5</number>
+             <number>6</number>
             </property>
             <property name="minimum">
              <double>-10.000000000000000</double>
@@ -147,7 +147,7 @@
              <string> 1/A</string>
             </property>
             <property name="decimals">
-             <number>5</number>
+             <number>6</number>
             </property>
             <property name="minimum">
              <double>-10.000000000000000</double>
@@ -179,7 +179,7 @@
              <string> 1/A</string>
             </property>
             <property name="decimals">
-             <number>4</number>
+             <number>6</number>
             </property>
             <property name="minimum">
              <double>-1.000000000000000</double>
@@ -217,7 +217,7 @@
              <string> 1/A</string>
             </property>
             <property name="decimals">
-             <number>4</number>
+             <number>6</number>
             </property>
             <property name="minimum">
              <double>-1.000000000000000</double>

--- a/test/integration/quicknxs/interfaces/data_handling/test_processing_workflow.py
+++ b/test/integration/quicknxs/interfaces/data_handling/test_processing_workflow.py
@@ -56,3 +56,70 @@ def test_orso_output(data_server, tmpdir):
         datasets = load_orso(os.path.join(tmpdir, file))
         for i, dataset in enumerate(datasets):
             assert len(dataset.data) == reflectivity_data_lengths[i]
+
+
+@pytest.mark.datarepo
+def test_smoothing_without_slice_export(data_server, tmpdir):
+    """Regression test for KeyError when smoothing without exporting slices.
+
+    Reproduces the exact scenario reported by Marie:
+    - User checks "Apply intensity smoothing" but NOT "Export off-spec slices"
+    - Smooth dialog opens and adds most off-spec params (x_axis, region, bins, sigmas)
+    - Slice dialog does NOT open, so slice params (qz_min/max) are never added
+    - smooth_offspec() internally needs slice params for internal calculations
+
+    This verifies that DEFAULT_OPTIONS provides missing parameters via merge pattern.
+    """
+    Configuration.setup_default_values()
+    conf = Configuration()
+    conf.cut_first_n_points = 0
+    conf.cut_last_n_points = 0
+    manager = DataManager(data_server.directory)
+
+    # Simulate the exact state after ReductionDialog + OffSpecParametersDialog:
+    # ReductionDialog.get_options() returns basic flags
+    output_options = {
+        "export_specular": False,
+        "export_offspec": False,
+        "apply_smoothing": True,  # User checked this
+        "export_offspec_smooth": True,
+        "export_offspec_slices": False,  # User did NOT check this
+        "output_directory": str(tmpdir),
+    }
+
+    # OffSpecParametersDialog.get_parameters() adds these (simulate dialog opening):
+    output_options.update(
+        {
+            "off_spec_x_axis": 0,  # DELTA_KZ_VS_QZ
+            "off_spec_x_min": -0.1,
+            "off_spec_x_max": 0.1,
+            "off_spec_y_min": 0.0,
+            "off_spec_y_max": 0.15,
+            "off_spec_nxbins": 120,
+            "off_spec_nybins": 120,
+            "off_spec_sigmas": 3,
+            "off_spec_sigmax": 0.001,
+            "off_spec_sigmay": 0.001,
+            # NOTE: off_spec_slice_qz_min/max are intentionally MISSING
+            # because OffSpecSliceDialog never opened (export_offspec_slices=False)
+        }
+    )
+
+    # This simulates the exact dict passed to ProcessingWorkflow in the bug scenario
+    pw = ProcessingWorkflow(manager, output_options)
+
+    # Verify the merge pattern filled in the missing slice parameters
+    assert pw.output_options["off_spec_slice_qz_min"] == 0.05  # from DEFAULT_OPTIONS
+    assert pw.output_options["off_spec_slice_qz_max"] == 0.07  # from DEFAULT_OPTIONS
+
+    # Verify user-provided values were NOT overwritten by defaults
+    assert pw.output_options["off_spec_x_min"] == -0.1  # user's value preserved
+    assert pw.output_options["off_spec_sigmas"] == 3  # user's value preserved
+
+    # Load test data
+    file_path = data_server.path_to("REF_M_42112.nxs.h5")
+    manager.load(file_path, conf)
+    manager.add_active_to_reduction()
+
+    # This should NOT raise KeyError: 'off_spec_slice_qz_min'
+    pw.offspec(raw=False, binned=False, smooth=True, slices=False)


### PR DESCRIPTION
## Description of work:

This PR fixes two bugs discovered during testing of the off-specular smoothing feature:

1. **KeyError on missing parameters**: Smoothing failed when slice export was disabled because `ProcessingWorkflow` received partial parameters from opened dialogs but replaced `DEFAULT_OPTIONS` entirely instead of merging. Fixed by changing init to merge pattern (`DEFAULT_OPTIONS.copy()` + `update()`) and adding 13 off-spec defaults.

2. **Reduced precision in UI**: The region parameter spinboxes had 4-5 decimal places instead of 6, causing parameter truncation (e.g., -0.10978 instead of -0.109784) that created small discrepancies in the smoothed output. All region parameters now use 6 decimals.

**Changes:**
- Modified `ProcessingWorkflow.__init__` to merge defaults with user options
- Added comprehensive off-specular defaults to `DEFAULT_OPTIONS` 
- Increased decimal precision to 6 for region parameter spinboxes
- Added regression test `test_smoothing_without_slice_export`

Check all that apply:
- [ ] updated documentation and checked that it looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [x] Source added/refactored
- [ ] Added unit tests
- [x]] Added integration tests

**References:**
N/A

---

# :warning: Manual test for the reviewer
([instructions to set up the environment](https://reflectivity-ui.readthedocs.io/en/latest/developer/environment.html))

---

# Check list for the reviewer
- [ ] best software practices
    + [x] clearly named variables (better to be verbose in variable names)
    + [x] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date and looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] code comments added when explaining intent