### PR TITLE
Modify the sync-version task to use RC tag if available

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -9,6 +9,8 @@ environments:
     - url: https://prefix.dev/pixi-build-backends/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -4331,10 +4333,9 @@ packages:
   timestamp: 1743692373820
 - pypi: ./
   name: quicknxs
-  version: 4.16.0.dev26
-  sha256: bc3379a515b7b22f99278a185603e257d5756d2eeeb909cd3c92386218521daf
+  version: 4.17.0.dev32
+  sha256: c30e247ac39b2c41953fc6db1d0f92b18f8bcf3fcbcfdef674c27602af9a1136
   requires_python: '>=3.10,<3.13'
-  editable: true
 - conda: https://conda.anaconda.org/conda-forge/linux-64/rapidjson-1.1.0.post20240409-h3f2d84a_2.conda
   sha256: f87f265263a1ddbc50b98e2c2bcaa2bac63da3acc09267815dd0f4bd614cd902
   md5: 65e2f30d532b4ae2063a424c185cc678

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,7 +181,7 @@ clean-all = { description = "Clean all artifacts", depends-on = [
     "clean-conda",
     "clean-docs",
 ] }
-sync-version = { cmd = 'version=$(python -m versioningit); toml set tool.pixi.package.version "$version" --toml-path pyproject.toml', description = "Sync pyproject.toml version with Git version" }
+sync-version = { cmd = '''bash -c 'RC_TAG=$(git tag --points-at HEAD | grep rc | head -1); if [ -n "$RC_TAG" ]; then version="${RC_TAG#v}"; else version=$(python -m versioningit); fi; toml set tool.pixi.package.version "$version" --toml-path pyproject.toml' ''', description = "Sync pyproject.toml version with Git version (uses RC tag directly if on one, otherwise uses versioningit)" }
 reset-version = { cmd = "toml set tool.pixi.package.version \"0.0.0\" --toml-path pyproject.toml", description = "Reset the package version to 0.0.0" }
 
 ##########################


### PR DESCRIPTION
## Description of work:

This change is related to the recent change to ignore tags matching "*rc*" when calculating version distance in `versioningit`: https://github.com/neutrons/quicknxs/pull/271.

One problem with that change is that `versioningit` is also used for updating the version during conda package builds. This PR updates the `sync-version` pixi task, which temporarily adds the version number to `pyproject.toml` during package builds, to use the version from the RC tag if available on the head commit and otherwise use versioningit as before.

Check all that apply:
(if not, provide an explanation in the work description)
- [ ] updated documentation and checked that it looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests

**References:**
- Links to IBM EWM items:
- Links to related issues or pull requests:


# :warning: Manual test for the reviewer
([instructions to set up the environment](https://reflectivity-ui.readthedocs.io/en/latest/developer/environment.html))

# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date and looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] code comments added when explaining intent
