### PR TITLE
Custom `versioningit` next_version method

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -9,6 +9,8 @@ environments:
     - url: https://prefix.dev/pixi-build-backends/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -4331,10 +4333,9 @@ packages:
   timestamp: 1743692373820
 - pypi: ./
   name: quicknxs
-  version: 4.16.0.dev26
-  sha256: bc3379a515b7b22f99278a185603e257d5756d2eeeb909cd3c92386218521daf
+  version: 4.17.0.dev20260324163716
+  sha256: f7e129697a1ed556b1446798207a46dfd7d7b50ab9aa41ec6453c6168fc3b7a1
   requires_python: '>=3.10,<3.13'
-  editable: true
 - conda: https://conda.anaconda.org/conda-forge/linux-64/rapidjson-1.1.0.post20240409-h3f2d84a_2.conda
   sha256: f87f265263a1ddbc50b98e2c2bcaa2bac63da3acc09267815dd0f4bd614cd902
   md5: 65e2f30d532b4ae2063a424c185cc678

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,21 +37,23 @@ artifacts = ["*.yml", "*.yaml", "*.ini", "*.gx", "*.json", "*.ui"]
 source-file = "src/quicknxs/_version.py"
 build-file = "quicknxs/_version.py"
 
+[tool.hatch.build.targets.sdist]
+include = ["tools/"]
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/quicknxs"]
 
 [tool.versioningit.vcs]
 method = "git"
 default-tag = "4.0.0"
-exclude = ["*rc*"]
 
 [tool.versioningit.next-version]
-method = "minor"
+method = {module = "_next_version", value = "next_version", module-dir = "tools"}
 
 [tool.versioningit.format]
-distance = "{next_version}.dev{distance}"
+distance = "{next_version}.dev{committer_date:%Y%m%d%H%M%S}"
 dirty = "{version}"
-distance-dirty = "{next_version}.dev{distance}"
+distance-dirty = "{next_version}.dev{committer_date:%Y%m%d%H%M%S}"
 
 [tool.versioningit.write]
 file = "src/quicknxs/_version.py"

--- a/tools/_next_version.py
+++ b/tools/_next_version.py
@@ -1,0 +1,27 @@
+"""Custom versioningit next-version method.
+
+When the last tag is a pre-release (RC, alpha, beta), returns the base release
+version unchanged, so that dev versions stay in the same epoch throughout the
+entire RC cycle (e.g. ``4.14.0.dev...``) rather than bumping to the next minor
+version (``4.15.0.dev...``).
+
+For production tags, the minor version is bumped as usual.
+
+Example outcomes:
+  last tag v4.13.0  -> next_version = 4.14.0  -> dev: 4.14.0.dev20241001...
+  last tag v4.14.0rc1 -> next_version = 4.14.0  -> dev: 4.14.0.dev20241015...
+  last tag v4.14.0rc2 -> next_version = 4.14.0  -> dev: 4.14.0.dev20241020...
+  last tag v4.14.0  -> next_version = 4.15.0  -> dev: 4.15.0.dev20241025...
+"""
+
+from packaging.version import Version
+
+
+def next_version(*, version: str, **_kwargs: object) -> str:
+    v = Version(version)
+    if v.pre is not None:
+        # Pre-release tag (rc/alpha/beta): keep the same base release so dev
+        # versions stay as e.g. 4.14.0.dev... across the whole RC cycle.
+        return ".".join(str(x) for x in v.release)
+    major, minor, *_ = v.release
+    return f"{major}.{minor + 1}.0"


### PR DESCRIPTION
## Description of work:

Use custom `versioningit` `next_version` method to ensure dev version numbers always increase monotonically with respect to the latest _prod_ release. Use date rather than distance (number of commits) to identify the dev version, since the distance is reset whenever an RC tag is created.

Check all that apply:
(if not, provide an explanation in the work description)
- [ ] updated documentation and checked that it looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests

**References:**
- Links to IBM EWM items:
- Links to related issues or pull requests:


# :warning: Manual test for the reviewer
([instructions to set up the environment](https://reflectivity-ui.readthedocs.io/en/latest/developer/environment.html))

# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date and looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] code comments added when explaining intent
