### PR TITLE
Fix mismatch in active run between file list and reduction table

### DIFF
--- a/src/quicknxs/interfaces/data_handling/data_set.py
+++ b/src/quicknxs/interfaces/data_handling/data_set.py
@@ -684,7 +684,9 @@ class NexusData(object):
         configuration: Configuration
             Reduction configuration
         """
-        self.file_path = FilePath(file_path).path  # sort the paths if more than one
+        fp = FilePath(file_path)
+        self.file_path = fp.path  # sort the paths if more than one
+        self.file_name = fp.basename
         self.number: str = ""  # can be a single number (e.g. '1234') or a composite (e.g '1234:1239+1245')
         self.configuration = configuration
         self.cross_sections: Dict[str, CrossSectionData] = {}
@@ -895,8 +897,9 @@ class NexusData(object):
         ws = api.Scale(InputWorkspace=output_ws, OutputWorkspace=output_ws, factor=quicknxs_scale, Operation="Multiply")
         _ws = ws if len(ws_list) > 1 else [ws]
         for xs in _ws:
-            # add suffix to avoid overwriting ws in mantid data service, needed for multiple peaks
-            api.RenameWorkspace(str(xs), str(xs) + ws_suffix)
+            # add suffix to avoid overwriting ws in mantid data service, needed for multiple peaks and summed runs
+            # for example: 42112_On_Off__reflectivity -> 42112_On_Off__reflectivity_42112+42113_1
+            api.RenameWorkspace(str(xs), str(xs) + "_" + self.number + ws_suffix)
             xs_id = xs.getRun().getProperty("cross_section_id").value
             self.cross_sections[xs_id].q = xs.readX(0)[:].copy()
             self.cross_sections[xs_id]._r = np.ma.masked_equal(xs.readY(0)[:].copy(), 0)

--- a/src/quicknxs/interfaces/data_manager.py
+++ b/src/quicknxs/interfaces/data_manager.py
@@ -26,8 +26,6 @@ class DataManager(object):
     ----------
     current_directory
         Current directory
-    current_file_name
-        Current file name, used for file list table to set the current item
     _nexus_data
         Current data set
     active_cross_section
@@ -56,7 +54,6 @@ class DataManager(object):
 
     def __init__(self, current_directory: str):
         self.current_directory: str = current_directory
-        self.current_file_name: Optional[str] = None
         self._nexus_data: Optional[NexusData] = None
 
         self.active_cross_section: Optional[CrossSectionData] = None
@@ -99,6 +96,12 @@ class DataManager(object):
         if self._nexus_data is None:
             return None
         return self._nexus_data.file_path
+
+    @property
+    def current_file_name(self):
+        if self._nexus_data is None:
+            return None
+        return self._nexus_data.file_name
 
     @property
     def reduction_list(self) -> list[NexusData]:
@@ -493,7 +496,7 @@ class DataManager(object):
         # Actions taken in this function:
         # 1. Find if the file has been loaded in the past. Retrieve the cache when force==False
         # 2. If file not in cache, or if force==True: invoke NexusData.load()
-        # 3. Update attributes _nexus_data, current_directory, and current_file_name
+        # 3. Update attributes _nexus_data and current_directory
         # 4. If we're overwriting cached data that was allocated in the reduction_list and direct_beam_list,
         #    then assign the new data to the proper indexes in lists reduction_list and direct_beam_list
         # 5. Compute reflectivity if data is loaded from file
@@ -507,16 +510,19 @@ class DataManager(object):
         if progress is not None:
             progress(10, "Loading data...")
 
-        # Check whether the file has already been loaded (in cache)
-        for i in range(len(self._cache)):
-            if self._cache[i].file_path == file_path:
+        # Search through current reduction list, direct beam list, and cache for the file path.
+        # If found and force is False, the matching data will become the active data in the UI.
+        nexus_data_search_list = self.reduction_list + self.direct_beam_list + self._cache
+        for _nxs_data in nexus_data_search_list:
+            if _nxs_data.file_path == file_path:
                 if force:
                     # Check whether the data is in the reduction list before removing it
-                    reduction_list_id = self.find_data_in_reduction_list(self._cache[i])
-                    direct_beam_list_id = self.find_data_in_direct_beam_list(self._cache[i])
-                    self._cache.pop(i)
+                    reduction_list_id = self.find_data_in_reduction_list(_nxs_data)
+                    direct_beam_list_id = self.find_data_in_direct_beam_list(_nxs_data)
+                    if _nxs_data in self._cache:
+                        self._cache.remove(_nxs_data)
                 else:
-                    nexus_data = self._cache[i]
+                    nexus_data = _nxs_data
                     is_from_cache = True
                 break
 
@@ -533,13 +539,14 @@ class DataManager(object):
         if progress is not None:
             progress(80, "Calculating...")
 
+        # Set the current data to the loaded data, whether from cache or from file
         self._nexus_data = nexus_data
+
         # Example: '/SNS/REF_M/IPTS-25531/nexus/REF_M_38198.nxs.h5+/SNS/REF_M/IPTS-25531/nexus/REF_M_38199.nxs.h5'
         # will be split into directory='/SNS/REF_M/IPTS-25531/nexus' and
         # file_name='REF_M_38198.nxs.h5+REF_M_38199.nxs.h5'
         directory, file_name = FilePath(file_path).split()
         self.current_directory = directory
-        self.current_file_name = file_name
         self.set_active_cross_section(0)
 
         # If we didn't get this data set from our cache, add it and compute its reflectivity.

--- a/src/quicknxs/interfaces/event_handlers/main_handler.py
+++ b/src/quicknxs/interfaces/event_handlers/main_handler.py
@@ -741,8 +741,8 @@ class MainHandler:
         file_path = getattr(self, dialog_opening_method)(filter_=filter_)
 
         if file_path:
-            self.open_file(file_path)
             self.update_file_list(file_path)
+            self.open_file(file_path)
 
     def file_open_dialog(self):
         """GUI callback for backend MainHandler._file_open_dialog."""

--- a/src/quicknxs/interfaces/event_handlers/main_handler.py
+++ b/src/quicknxs/interfaces/event_handlers/main_handler.py
@@ -1158,6 +1158,7 @@ class MainHandler:
 
         self.main_window.plotActiveTab()
         self.main_window.initiate_reflectivity_or_intensity_plot.emit()
+        self.main_window.initiate_projection_plot.emit(False)
         self.main_window.update_specular_viewer.emit()
 
     def add_direct_beam(self, silent=False):

--- a/src/quicknxs/interfaces/event_handlers/main_handler.py
+++ b/src/quicknxs/interfaces/event_handlers/main_handler.py
@@ -108,6 +108,15 @@ class MainHandler:
         """Return the QTableWidget for the data tab with the given index."""
         return self.ui.tabWidget.widget(tab_index).findChild(QtWidgets.QTableWidget)
 
+    def get_tab_index_for_reduction_table(self, table_widget: QtWidgets.QTableWidget) -> int:
+        """Return the tab index that owns the given reduction table widget."""
+        for i in range(self.ui.tabWidget.count()):
+            if i == self.DIRECT_BEAM_TAB_INDEX:
+                continue
+            if self.get_reduction_table_by_index(i) is table_widget:
+                return i
+        return self.MAIN_DATA_TAB_INDEX  # safe fallback
+
     def new_progress_reporter(self):
         """Return a progress reporter."""
         return ProgressReporter(progress_bar=self.progress_bar, status_bar=self.status_bar_handler)
@@ -216,6 +225,8 @@ class MainHandler:
         for i in range(len(cross_sections), 12):
             getattr(self.ui, "selectedCrossSection%i" % i).hide()
         self.main_window.auto_change_active = False
+
+        self.active_data_changed()
 
         # Emit signals to update the UI and plots
         self.main_window.file_loaded_signal.emit()
@@ -358,12 +369,11 @@ class MainHandler:
         else:
             self.ui.matched_direct_beam_label.setText("None")
 
-    def update_info(self):
+    def update_overview_run_info_from_active_run(self):
         """Update metadata shown in the overview tab."""
         self.main_window.auto_change_active = True
         d = self._data_manager.active_cross_section
         self.populate_from_configuration(d.configuration)
-        self.main_window.initiate_projection_plot.emit(False)
         QtWidgets.QApplication.instance().processEvents()
 
         if self.ui.set_dangle0_checkbox.isChecked():
@@ -409,8 +419,6 @@ class MainHandler:
 
         # Update reduction tables
         self.update_tables()
-
-        self.active_data_changed()
 
         self.main_window.auto_change_active = False
 
@@ -492,8 +500,7 @@ class MainHandler:
             new_list = _updated_current_list()
         # Use case 2: a composite from using Open Sum
         elif file_path.is_composite:
-            file_dir, file_name = file_path.split()
-            self._data_manager.current_file_name = file_path.basename
+            file_dir, _ = file_path.split()
             # Use case 2.1: the composite is made up of files in the current directory
             if file_dir == self._data_manager.current_directory:
                 new_list = sorted(_updated_current_list() + [file_path.basename])
@@ -508,15 +515,13 @@ class MainHandler:
                 file_dir = query_path
                 if file_dir != self._data_manager.current_directory:  # User changed directory
                     _update_current_directory(file_dir)
-                    self._data_manager.current_file_name = self._data_manager.current_event_files[0]
                     new_list = self._data_manager.current_event_files
                 else:
                     # TODO FIXME discovered from #93.  This path is not checked and thus problematic
                     new_list = None
             # Use case 3.2: a single path pointing to a file in the current or new directory
             else:
-                file_dir, file_name = file_path.split()
-                self._data_manager.current_file_name = file_name
+                file_dir, _ = file_path.split()
                 if file_dir == self._data_manager.current_directory:  # User selected a new file in the directory
                     new_list = _updated_current_list()
                 else:  # User selected a new file in a new directory
@@ -736,8 +741,8 @@ class MainHandler:
         file_path = getattr(self, dialog_opening_method)(filter_=filter_)
 
         if file_path:
-            self.update_file_list(file_path)
             self.open_file(file_path)
+            self.update_file_list(file_path)
 
     def file_open_dialog(self):
         """GUI callback for backend MainHandler._file_open_dialog."""
@@ -873,12 +878,19 @@ class MainHandler:
         """
         self.main_window.auto_change_active = True
 
-        # Get the current tab index to use the correct button group
-        current_tab_index = self.ui.tabWidget.currentIndex()
+        # Resolve the button group for the tab that owns this table
+        current_tab_index = self.get_tab_index_for_reduction_table(table_widget)
         if current_tab_index not in self.reduction_table_button_groups:
             self.reduction_table_button_groups[current_tab_index] = QtWidgets.QButtonGroup(self.main_window)
 
         button_group = self.reduction_table_button_groups[current_tab_index]
+
+        # Remove the old radio button from the group before replacing the cell widget
+        existing = table_widget.cellWidget(idx, ReductionTableColumn.ACTIVE)
+        if existing is not None:
+            old_btn = existing.findChild(QtWidgets.QRadioButton)
+            if old_btn is not None:
+                button_group.removeButton(old_btn)
 
         # radio button for active data (layout inside a widget to center it)
         radio_widget = ActiveDataRadioButton(self, is_active=(data == self._data_manager.active_cross_section), idx=idx)
@@ -967,6 +979,8 @@ class MainHandler:
                 continue
             tab_widget = self.get_reduction_table_by_index(itab)
             tab_widget.setRowCount(0)
+        # reset button groups so stale entries don't accumulate across load cycles
+        self.reduction_table_button_groups = {self.MAIN_DATA_TAB_INDEX: QtWidgets.QButtonGroup(self.main_window)}
         # remove additional data tabs
         self.main_window.reset_data_tabs()
 
@@ -1113,7 +1127,7 @@ class MainHandler:
         # If the changed data set is the active data, also change the UI
         if self._data_manager.is_active(refl):
             self.main_window.auto_change_active = True
-            self.update_info()
+            self.update_overview_run_info_from_active_run()
             self.main_window.auto_change_active = False
         elif not refl.is_direct_beam():
             # If the changed data set is another data run, only need to update the UI reduction table,
@@ -1199,6 +1213,8 @@ class MainHandler:
         """Remove all items from the direct beam list."""
         self._data_manager.clear_direct_beam_list()
         self.ui.directBeamTable.setRowCount(0)
+        # reset the button group so stale entries don't accumulate across load cycles
+        self.direct_beam_button_group = QtWidgets.QButtonGroup(self.main_window)
         self.ui.direct_beam_list_label.setText("None")
         self.main_window.initiate_reflectivity_or_intensity_plot.emit()
 
@@ -1240,6 +1256,13 @@ class MainHandler:
         """
         # Block signals to prevent recursion
         self.main_window.auto_change_active = True
+
+        # Explicitly remove the old radio button from the group before replacing the cell widget
+        existing = self.ui.directBeamTable.cellWidget(idx, DirectBeamTableColumn.ACTIVE)
+        if existing is not None:
+            old_btn = existing.findChild(QtWidgets.QRadioButton)
+            if old_btn is not None:
+                self.direct_beam_button_group.removeButton(old_btn)
 
         # radio button for active data (layout inside a widget to center it)
         radio_widget = ActiveDataRadioButton(
@@ -1328,7 +1351,7 @@ class MainHandler:
         # Update UI if this data set is the active one
         if self._data_manager.is_active(data):
             self.main_window.auto_change_active = True
-            self.update_info()
+            self.update_overview_run_info_from_active_run()
             self.main_window.auto_change_active = False
 
         # Recalculate reflectivity for runs with this direct beam
@@ -1347,7 +1370,16 @@ class MainHandler:
         self.main_window.initiate_projection_plot.emit(True)
 
     def active_data_changed(self):
-        """Actions to be taken once the active data set has changed."""
+        """Actions to be taken once the active data set has changed.
+
+        Updates the UI to highlight the active data set in the reduction and
+        direct beam tables, and updates the radio button states.
+
+        Also syncs the highlighted file in the file list.
+        """
+        if self._data_manager.active_cross_section is None:
+            return
+        logging.info(f"Active data changed to {self._data_manager.active_cross_section.number}")
         # If we update an entry, it's because that data is currently active.
         # Highlight it and un-highlight the other ones.
         self.main_window.auto_change_active = True
@@ -1362,9 +1394,8 @@ class MainHandler:
                     run_num.setBackground(QColors.white)
             # Set the radio button states
             active_cell = self.reduction_table.cellWidget(i, ReductionTableColumn.ACTIVE)
-            if active_cell is not None:
-                radio_button = active_cell.findChild(QtWidgets.QRadioButton)
-                radio_button.setChecked(i == idx)
+            if active_cell is not None and isinstance(active_cell, ActiveDataRadioButton):
+                active_cell.set_checked_block_signals(i == idx)
 
         idx = self._data_manager.find_active_direct_beam_id()
         for i in range(self.ui.directBeamTable.rowCount()):
@@ -1377,9 +1408,20 @@ class MainHandler:
                     item.setBackground(QColors.white)
             # Set the radio button states
             active_cell = self.ui.directBeamTable.cellWidget(i, DirectBeamTableColumn.ACTIVE)
-            if active_cell is not None:
-                radio_button = active_cell.findChild(QtWidgets.QRadioButton)
-                radio_button.setChecked(i == idx)
+            if active_cell is not None and isinstance(active_cell, ActiveDataRadioButton):
+                active_cell.set_checked_block_signals(i == idx)
+
+        # Find the file corresponding to the active data and highlight it in the file list
+        current_file_name = self._data_manager.current_file_name
+        for i in range(self.ui.file_list.count()):
+            list_item = self.ui.file_list.item(i)
+            if list_item is not None:
+                list_item_file_name = list_item.text()
+                if list_item_file_name == current_file_name:
+                    self.ui.file_list.blockSignals(True)
+                    self.ui.file_list.setCurrentRow(i)
+                    self.ui.file_list.blockSignals(False)
+                    break
 
         self.main_window.auto_change_active = False
 

--- a/src/quicknxs/interfaces/main_window.py
+++ b/src/quicknxs/interfaces/main_window.py
@@ -93,7 +93,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.initialize_instrument()
         self.hide_unsupported()
 
-        self.file_loaded_signal.connect(self.file_handler.update_info)
+        self.file_loaded_signal.connect(self.file_handler.update_overview_run_info_from_active_run)
         self.file_loaded_signal.connect(self.file_handler.update_daslog)
         self.file_loaded_signal.connect(self.plotActiveTab)
 
@@ -333,13 +333,12 @@ class MainWindow(QtWidgets.QMainWindow):
         self.file_handler.reduction_table_right_click(pos, True)
 
     def set_active_direct_beam(self, checked: bool, row: int):
-        """Select a data set when the user double-clicks on a run number (col 0) in the direct beam table."""
+        """Select a data set when the user changes the active run radio button (col 0) in the direct beam table."""
         if not checked:
             return
         self.data_manager.set_active_data_from_direct_beam_list(row)
         self.file_loaded()
-        # TODO: why is this commented out? (Glass)
-        # self.file_handler.active_data_changed()
+        self.file_handler.active_data_changed()
 
     def direct_beam_table_right_click(self, pos: QtCore.QPoint):
         """Handle right-click on the direct beam table."""
@@ -510,9 +509,8 @@ class MainWindow(QtWidgets.QMainWindow):
             self.data_manager.update_active_direct_beam()
 
         if self.data_manager.data_sets:
-            # Note: Don't call active_data_changed() directly here - it's already called via
-            # file_loaded_signal -> update_info() -> active_data_changed()
             self.file_loaded()
+            self.file_handler.active_data_changed()
 
     ### End of data tab management
 

--- a/src/quicknxs/ui/active_radio_button.py
+++ b/src/quicknxs/ui/active_radio_button.py
@@ -9,17 +9,6 @@ if TYPE_CHECKING:
     from quicknxs.interfaces.event_handlers.main_handler import MainHandler
 
 
-class NoToggleRadioButton(QRadioButton):
-    """A QRadioButton that cannot be toggled off once selected."""
-
-    def mousePressEvent(self, event):
-        """Override mouse press event to prevent toggling off."""
-        if self.isChecked():
-            event.ignore()
-        else:
-            super().mousePressEvent(event)
-
-
 class ActiveDataRadioButton(QWidget):
     """A QWidget that represents the active data selection."""
 
@@ -40,7 +29,7 @@ class ActiveDataRadioButton(QWidget):
     def initUI(self):
         """Initialize the UI components."""
 
-        self.radio_button = NoToggleRadioButton()
+        self.radio_button = QRadioButton()
         self.radio_button.setChecked(self.is_active)
 
         # Connect to the appropriate method based on whether this is a direct beam or reduction table
@@ -60,6 +49,12 @@ class ActiveDataRadioButton(QWidget):
         layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(self.radio_button)
         self.setLayout(layout)
+
+    def set_checked_block_signals(self, checked: bool) -> None:
+        """Set radio button state without emitting signals."""
+        self.radio_button.blockSignals(True)
+        self.radio_button.setChecked(checked)
+        self.radio_button.blockSignals(False)
 
     def _get_current_row(self):
         """Find the current row index of this widget in the table."""

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,14 +3,18 @@ r"""Fixtures for pytest."""
 # standard imports
 # 3rd-party imports
 import glob
+import logging
 import os
 import sys
 from pathlib import Path
 
+import numpy as np
 import pytest
 from PyQt5.QtCore import QSettings
+from qtpy import QtWidgets
 
 from quicknxs.interfaces.configuration import Configuration
+from quicknxs.interfaces.data_handling.data_set import CrossSectionData, NexusData
 from quicknxs.interfaces.data_handling.filepath import RunNumbers
 from quicknxs.interfaces.data_handling.instrument import Instrument
 from quicknxs.interfaces.data_manager import DataManager
@@ -20,6 +24,18 @@ from test.ui import ui_utilities
 pytest_plugins = ["mantid.fixtures"]
 
 this_module_path = sys.modules[__name__].__file__
+
+
+def pytest_configure(config):
+    """Suppress debug logging from pyvirtualdisplay.
+
+    pytest-xvfb tears down the virtual display after pytest has already closed
+    its log-capture streams.  pyvirtualdisplay emits several log.debug() calls
+    during that teardown, which hit the closed stream and print harmless but
+    noisy '--- Logging error ---' tracebacks to stderr.  Raising the logger
+    level to WARNING filters those messages before they ever reach a handler.
+    """
+    logging.getLogger("pyvirtualdisplay").setLevel(logging.WARNING)
 
 
 ################################################
@@ -180,3 +196,76 @@ def data_manager_with_data_factory(data_server):
         return manager
 
     return _create
+
+
+@pytest.fixture
+def main_window_with_mock_runs(qtbot, mocker, tmp_path):
+    """MainWindow with two mock reflected runs and two mock direct beam runs.
+
+    Injects NexusData objects directly into the DataManager (no Nexus file content is read),
+    and pre-populates the file list widget with their file names.
+
+    Empty placeholder files are created in tmp_path so that open_file()'s existence check
+    passes when the file list selection signal triggers file_open_from_list().
+    DataManager.load() finds each NexusData by its full path in direct_beam_list /
+    reduction_list, so no actual Nexus data is ever parsed.
+
+    Both MainWindow.file_loaded and MainHandler.file_loaded are patched out so that
+    the plotting machinery is not triggered. set_active_reduction_data still calls
+    active_data_changed() explicitly after file_loaded returns.
+    """
+    config = Configuration()
+    xs = CrossSectionData("Off_Off", config)
+    xs.tof_edges = np.array([0.1, 0.2, 0.3, 0.4])
+
+    names = ["REF_M_40785.nxs.h5", "REF_M_40782.nxs.h5", "REF_M_40786.nxs.h5", "REF_M_40787.nxs.h5"]
+    for name in names:
+        (tmp_path / name).touch()
+
+    run_a = NexusData(str(tmp_path / "REF_M_40785.nxs.h5"), config)
+    run_a.cross_sections["Off_Off"] = xs
+
+    run_b = NexusData(str(tmp_path / "REF_M_40782.nxs.h5"), config)
+    run_b.cross_sections["Off_Off"] = xs
+
+    run_db = NexusData(str(tmp_path / "REF_M_40786.nxs.h5"), config)
+    run_db.cross_sections["Off_Off"] = xs
+
+    run_db2 = NexusData(str(tmp_path / "REF_M_40787.nxs.h5"), config)
+    run_db2.cross_sections["Off_Off"] = xs
+
+    main_window = MainWindow()
+    qtbot.addWidget(main_window)
+    handler = main_window.file_handler
+
+    dm = main_window.data_manager
+    dm.current_directory = str(tmp_path)
+    dm.peak_reduction_lists[dm.active_reduction_list_index] = [run_a, run_b]
+    dm.direct_beam_list = [run_db, run_db2]
+    # Set an initial active run so that initialize_additional_reduction_table can read
+    # active_cross_section.name if addDataTable() is called during a test.
+    dm._nexus_data = run_a
+    dm.active_cross_section = xs
+
+    for name in names:
+        QtWidgets.QListWidgetItem(name, main_window.ui.file_list)
+
+    # Bypass the plotting machinery triggered by both call paths into file_loaded:
+    # - MainWindow.file_loaded() is called by set_active_reduction_data / set_active_direct_beam
+    # - MainHandler.file_loaded() is called directly by open_file (via file_open_from_list)
+    mocker.patch.object(main_window, "file_loaded")
+    # Retain only the call to active_data_changed to ensure the radio button state is updated
+    mocker.patch.object(handler, "file_loaded", side_effect=handler.active_data_changed)
+
+    # Populate the reduction table with the mock runs
+    xs_name = dm.active_cross_section.name
+    handler.reduction_table.setRowCount(len(dm.reduction_list))
+    for i, run in enumerate(dm.reduction_list):
+        handler.update_reduction_table(handler.reduction_table, i, run.cross_sections[xs_name])
+
+    # Populate the direct beam table with the mock runs
+    handler.direct_beam_table.setRowCount(len(dm.direct_beam_list))
+    for i, run in enumerate(dm.direct_beam_list):
+        handler.update_direct_beam_table(i, run.cross_sections[xs_name])
+
+    return main_window

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -221,12 +221,18 @@ def main_window_with_mock_runs(qtbot, mocker, tmp_path):
     names = ["REF_M_40785.nxs.h5", "REF_M_40782.nxs.h5", "REF_M_40786.nxs.h5", "REF_M_40787.nxs.h5"]
     for name in names:
         (tmp_path / name).touch()
+    # add summed file to file list
+    names.append("REF_M_40782.nxs.h5+REF_M_40785.nxs.h5")
 
     run_a = NexusData(str(tmp_path / "REF_M_40785.nxs.h5"), config)
     run_a.cross_sections["Off_Off"] = xs
 
-    run_b = NexusData(str(tmp_path / "REF_M_40782.nxs.h5"), config)
+    # run created with Open & Sum Multiple Files
+    run_b = NexusData(str(tmp_path / "REF_M_40782.nxs.h5") + "+" + str(tmp_path / "REF_M_40785.nxs.h5"), config)
     run_b.cross_sections["Off_Off"] = xs
+
+    run_c = NexusData(str(tmp_path / "REF_M_40782.nxs.h5"), config)
+    run_c.cross_sections["Off_Off"] = xs
 
     run_db = NexusData(str(tmp_path / "REF_M_40786.nxs.h5"), config)
     run_db.cross_sections["Off_Off"] = xs
@@ -240,7 +246,7 @@ def main_window_with_mock_runs(qtbot, mocker, tmp_path):
 
     dm = main_window.data_manager
     dm.current_directory = str(tmp_path)
-    dm.peak_reduction_lists[dm.active_reduction_list_index] = [run_a, run_b]
+    dm.peak_reduction_lists[dm.active_reduction_list_index] = [run_a, run_b, run_c]
     dm.direct_beam_list = [run_db, run_db2]
     # Set an initial active run so that initialize_additional_reduction_table can read
     # active_cross_section.name if addDataTable() is called during a test.

--- a/test/ui/test_direct_beam_table.py
+++ b/test/ui/test_direct_beam_table.py
@@ -60,7 +60,7 @@ def test_table_connections(qtbot, data_server):
     # Change the reference position and width in the main window
     main_window.ui.refXPos.setValue(200)
     main_window.ui.refXWidth.setValue(100)
-    main_window.file_handler.update_info()
+    main_window.file_handler.update_overview_run_info_from_active_run()
     assert main_window.ui.refXPos.value() == float(table.item(0, DBTableCols.PEAK_POSITION).text())
     assert main_window.ui.refXWidth.value() == float(table.item(0, DBTableCols.PEAK_WIDTH).text())
 

--- a/test/unit/quicknxs/interfaces/event_handlers/test_main_handler.py
+++ b/test/unit/quicknxs/interfaces/event_handlers/test_main_handler.py
@@ -478,13 +478,13 @@ class TestActiveDataChangedSyncsFileList:
         main_window.set_active_reduction_data(True, 0)
         assert data_manager._nexus_data == data_manager.reduction_list[0]
         assert main_window.ui.file_list.currentItem() is not None
-        assert "40785" in main_window.ui.file_list.currentItem().text()
+        assert main_window.ui.file_list.currentItem().text() == "REF_M_40785.nxs.h5"
 
         # Switch active run to row 1 and verify the file list highlights run 40782
         main_window.set_active_reduction_data(True, 1)
         assert data_manager._nexus_data == data_manager.reduction_list[1]
         assert main_window.ui.file_list.currentItem() is not None
-        assert "40782" in main_window.ui.file_list.currentItem().text()
+        assert main_window.ui.file_list.currentItem().text() == "REF_M_40782.nxs.h5+REF_M_40785.nxs.h5"
 
     def test_select_run_from_direct_beam_table(self, main_window_with_mock_runs):
         """Test that switching the active run in the direct beam table updates the file list selection."""
@@ -495,13 +495,13 @@ class TestActiveDataChangedSyncsFileList:
         main_window.set_active_direct_beam(True, 0)
         assert data_manager._nexus_data == data_manager.direct_beam_list[0]
         assert main_window.ui.file_list.currentItem() is not None
-        assert "40786" in main_window.ui.file_list.currentItem().text()
+        assert main_window.ui.file_list.currentItem().text() == "REF_M_40786.nxs.h5"
 
         # Switch to the data run and verify the file list highlights run 40787
         main_window.set_active_direct_beam(True, 1)
         assert data_manager._nexus_data == data_manager.direct_beam_list[1]
         assert main_window.ui.file_list.currentItem() is not None
-        assert "40787" in main_window.ui.file_list.currentItem().text()
+        assert main_window.ui.file_list.currentItem().text() == "REF_M_40787.nxs.h5"
 
     def test_select_run_from_file_list(self, main_window_with_mock_runs):
         """Test that selecting a file in the list updates the active run radio button"""
@@ -524,7 +524,7 @@ class TestActiveDataChangedSyncsFileList:
         assert _checked_row() == 0
 
         # Click on the second data run in the file list and verify that the correct row is checked
-        item = main_window.ui.file_list.findItems("40782", QtCore.Qt.MatchContains)[0]
+        item = main_window.ui.file_list.findItems("REF_M_40782.nxs.h5+REF_M_40785.nxs.h5", QtCore.Qt.MatchContains)[0]
         main_window.ui.file_list.setCurrentItem(item)
         assert data_manager._nexus_data == data_manager.reduction_list[1]
         assert _checked_row() == 1
@@ -539,13 +539,13 @@ class TestActiveDataChangedSyncsFileList:
         data_tab_widget.setCurrentIndex(main_window.file_handler.DIRECT_BEAM_TAB_INDEX)
         assert data_manager._nexus_data == data_manager.direct_beam_list[0]
         assert main_window.ui.file_list.currentItem() is not None
-        assert "40786" in main_window.ui.file_list.currentItem().text()
+        assert main_window.ui.file_list.currentItem().text() == "REF_M_40786.nxs.h5"
 
         # Switch to the main data tab and verify the file list highlights the active data run (40785)
         data_tab_widget.setCurrentIndex(main_window.file_handler.MAIN_DATA_TAB_INDEX)
         assert data_manager._nexus_data == data_manager.reduction_list[0]
         assert main_window.ui.file_list.currentItem() is not None
-        assert "40785" in main_window.ui.file_list.currentItem().text()
+        assert main_window.ui.file_list.currentItem().text() == "REF_M_40785.nxs.h5"
 
     def test_switching_between_multiple_data_tabs(self, main_window_with_mock_runs):
         """Test that the file list syncs correctly when the active data comes from a secondary reduction tab.
@@ -559,17 +559,17 @@ class TestActiveDataChangedSyncsFileList:
 
         # Add a second data tab; the runs from tab 1 are deep-copied into it
         main_window.addDataTable()
-        assert len(data_manager.peak_reduction_lists[2]) == 2
+        assert len(data_manager.peak_reduction_lists[2]) == 3
 
         # Make the second tab the active list and verify the first run is active
         data_tab_widget.setCurrentIndex(2)
         assert main_window.ui.file_list.currentItem() is not None
-        assert "40785" in main_window.ui.file_list.currentItem().text()
+        assert main_window.ui.file_list.currentItem().text() == "REF_M_40785.nxs.h5"
 
         # Switch to the second run in tab 2 (40782) and verify the file list updates
         main_window.set_active_reduction_data(True, 1)
         assert main_window.ui.file_list.currentItem() is not None
-        assert "40782" in main_window.ui.file_list.currentItem().text()
+        assert main_window.ui.file_list.currentItem().text() == "REF_M_40782.nxs.h5+REF_M_40785.nxs.h5"
 
 
 if __name__ == "__main__":

--- a/test/unit/quicknxs/interfaces/event_handlers/test_main_handler.py
+++ b/test/unit/quicknxs/interfaces/event_handlers/test_main_handler.py
@@ -466,107 +466,110 @@ def test_get_tab_index_for_reduction_table(qtbot):
     assert handler.get_tab_index_for_reduction_table(second_data_table) == second_tab_index
 
 
-@pytest.mark.datarepo
-def test_active_data_changed_syncs_file_list_from_reduction_table(qtbot):
-    """Test that switching the active run in the reduction table updates the file list selection."""
-    main_window = MainWindow()
-    data_manager = main_window.data_manager
-    qtbot.addWidget(main_window)
+class TestActiveDataChangedSyncsFileList:
+    """Test that the active run is synced between the reduction/direct beam tables and the file list in the UI."""
 
-    # Add two data runs to the reduction table (row 0 = run 40785, row 1 = run 40782)
-    ui_utilities.setText(main_window.numberSearchEntry, str(40785), press_enter=True)
-    ui_utilities.set_current_file_by_run_number(main_window, 40785)
-    main_window.actionAddRefl.triggered.emit()
-    ui_utilities.set_current_file_by_run_number(main_window, 40782)
-    main_window.actionAddRefl.triggered.emit()
+    def test_select_run_from_reduction_table(self, main_window_with_mock_runs):
+        """Test that switching the active run in the reduction table updates the file list selection."""
+        main_window = main_window_with_mock_runs
+        data_manager = main_window.data_manager
 
-    assert main_window.ui.reductionTable.rowCount() == 2
+        # Switch active run to row 0 and verify the file list highlights run 40785
+        main_window.set_active_reduction_data(True, 0)
+        assert data_manager._nexus_data == data_manager.reduction_list[0]
+        assert main_window.ui.file_list.currentItem() is not None
+        assert "40785" in main_window.ui.file_list.currentItem().text()
 
-    # Switch active run to row 0 and verify the file list highlights run 40785
-    main_window.set_active_reduction_data(True, 0)
-    assert data_manager._nexus_data == data_manager.reduction_list[0]
-    assert main_window.ui.file_list.currentItem() is not None
-    assert "40785" in main_window.ui.file_list.currentItem().text()
+        # Switch active run to row 1 and verify the file list highlights run 40782
+        main_window.set_active_reduction_data(True, 1)
+        assert data_manager._nexus_data == data_manager.reduction_list[1]
+        assert main_window.ui.file_list.currentItem() is not None
+        assert "40782" in main_window.ui.file_list.currentItem().text()
 
-    # Switch active run to row 1 and verify the file list highlights run 40782
-    main_window.set_active_reduction_data(True, 1)
-    assert data_manager._nexus_data == data_manager.reduction_list[1]
-    assert main_window.ui.file_list.currentItem() is not None
-    assert "40782" in main_window.ui.file_list.currentItem().text()
+    def test_select_run_from_direct_beam_table(self, main_window_with_mock_runs):
+        """Test that switching the active run in the direct beam table updates the file list selection."""
+        main_window = main_window_with_mock_runs
+        data_manager = main_window.data_manager
 
+        # Switch active to the direct beam run and verify the file list highlights run 40786
+        main_window.set_active_direct_beam(True, 0)
+        assert data_manager._nexus_data == data_manager.direct_beam_list[0]
+        assert main_window.ui.file_list.currentItem() is not None
+        assert "40786" in main_window.ui.file_list.currentItem().text()
 
-@pytest.mark.datarepo
-def test_active_data_changed_syncs_file_list_from_direct_beam_table(qtbot):
-    """Test that switching the active run in the direct beam table updates the file list selection."""
-    main_window = MainWindow()
-    data_manager = main_window.data_manager
-    qtbot.addWidget(main_window)
+        # Switch to the data run and verify the file list highlights run 40787
+        main_window.set_active_direct_beam(True, 1)
+        assert data_manager._nexus_data == data_manager.direct_beam_list[1]
+        assert main_window.ui.file_list.currentItem() is not None
+        assert "40787" in main_window.ui.file_list.currentItem().text()
 
-    # Add a direct beam run and a data run
-    ui_utilities.setText(main_window.numberSearchEntry, str(40786), press_enter=True)
-    ui_utilities.set_current_file_by_run_number(main_window, 40786)
-    main_window.actionAddDirectBeam.triggered.emit()
-    ui_utilities.set_current_file_by_run_number(main_window, 40785)
-    main_window.actionAddRefl.triggered.emit()
+    def test_select_run_from_file_list(self, main_window_with_mock_runs):
+        """Test that selecting a file in the list updates the active run radio button"""
+        main_window = main_window_with_mock_runs
+        data_manager = main_window.data_manager
+        handler = main_window.file_handler
 
-    assert main_window.ui.directBeamTable.rowCount() == 1
-    assert main_window.ui.reductionTable.rowCount() == 1
+        def _checked_row():
+            """Return the row index of the checked radio button, or None if none is checked."""
+            for i in range(handler.reduction_table.rowCount()):
+                cell = handler.reduction_table.cellWidget(i, ReductionTableColumn.ACTIVE)
+                if cell is not None and cell.radio_button.isChecked():
+                    return i
+            return None
 
-    # The data run should be active initially; verify file list reflects it
-    assert data_manager._nexus_data == data_manager.reduction_list[0]
-    assert main_window.ui.file_list.currentItem() is not None
-    assert "40785" in main_window.ui.file_list.currentItem().text()
+        # Click on the first data run in the file list and verify that the correct row is checked
+        item = main_window.ui.file_list.findItems("40785", QtCore.Qt.MatchContains)[0]
+        main_window.ui.file_list.setCurrentItem(item)
+        assert data_manager._nexus_data == data_manager.reduction_list[0]
+        assert _checked_row() == 0
 
-    # Switch active to the direct beam run and verify the file list updates
-    main_window.set_active_direct_beam(True, 0)
-    assert data_manager._nexus_data == data_manager.direct_beam_list[0]
-    assert main_window.ui.file_list.currentItem() is not None
-    assert "40786" in main_window.ui.file_list.currentItem().text()
+        # Click on the second data run in the file list and verify that the correct row is checked
+        item = main_window.ui.file_list.findItems("40782", QtCore.Qt.MatchContains)[0]
+        main_window.ui.file_list.setCurrentItem(item)
+        assert data_manager._nexus_data == data_manager.reduction_list[1]
+        assert _checked_row() == 1
 
-    # Switch back to the data run and verify the file list updates again
-    main_window.set_active_reduction_data(True, 0)
-    assert data_manager._nexus_data == data_manager.reduction_list[0]
-    assert main_window.ui.file_list.currentItem() is not None
-    assert "40785" in main_window.ui.file_list.currentItem().text()
+    def test_switching_between_data_and_direct_beam_tabs(self, main_window_with_mock_runs):
+        """Test that switching between the direct beam and data tabs updates the file list selection."""
+        main_window = main_window_with_mock_runs
+        data_manager = main_window.data_manager
+        data_tab_widget = main_window.ui.tabWidget
 
+        # Switch to the direct beam tab and verify the file list highlights the active direct beam run (40786)
+        data_tab_widget.setCurrentIndex(main_window.file_handler.DIRECT_BEAM_TAB_INDEX)
+        assert data_manager._nexus_data == data_manager.direct_beam_list[0]
+        assert main_window.ui.file_list.currentItem() is not None
+        assert "40786" in main_window.ui.file_list.currentItem().text()
 
-@pytest.mark.datarepo
-def test_active_data_changed_syncs_file_list_with_multiple_data_tabs(qtbot):
-    """Test that the file list syncs correctly when the active data comes from a secondary reduction tab.
+        # Switch to the main data tab and verify the file list highlights the active data run (40785)
+        data_tab_widget.setCurrentIndex(main_window.file_handler.MAIN_DATA_TAB_INDEX)
+        assert data_manager._nexus_data == data_manager.reduction_list[0]
+        assert main_window.ui.file_list.currentItem() is not None
+        assert "40785" in main_window.ui.file_list.currentItem().text()
 
-    Switching the active reduction list to tab 2 and calling active_data_changed() directly
-    verifies the file list sync without triggering the full tab-change event cycle.
-    """
-    main_window = MainWindow()
-    handler = MainHandler(main_window)
-    data_manager = main_window.data_manager
-    qtbot.addWidget(main_window)
+    def test_switching_between_multiple_data_tabs(self, main_window_with_mock_runs):
+        """Test that the file list syncs correctly when the active data comes from a secondary reduction tab.
 
-    # Add two data runs to the first reduction tab
-    ui_utilities.setText(main_window.numberSearchEntry, str(40785), press_enter=True)
-    ui_utilities.set_current_file_by_run_number(main_window, 40785)
-    main_window.actionAddRefl.triggered.emit()
-    ui_utilities.set_current_file_by_run_number(main_window, 40782)
-    main_window.actionAddRefl.triggered.emit()
+        Switching the active reduction list to tab 2 and calling active_data_changed() directly
+        verifies the file list sync without triggering the full tab-change event cycle.
+        """
+        main_window = main_window_with_mock_runs
+        data_manager = main_window.data_manager
+        data_tab_widget = main_window.ui.tabWidget
 
-    # Add a second data tab (the runs from tab 1 are copied into it)
-    main_window.addDataTable()
-    assert len(data_manager.peak_reduction_lists[2]) == 2
+        # Add a second data tab; the runs from tab 1 are deep-copied into it
+        main_window.addDataTable()
+        assert len(data_manager.peak_reduction_lists[2]) == 2
 
-    # Make the second tab the active list and select its second run (40782)
-    data_manager.set_active_reduction_list_index(2)
-    data_manager.set_active_data_from_reduction_list(1)
-    handler.active_data_changed()
+        # Make the second tab the active list and verify the first run is active
+        data_tab_widget.setCurrentIndex(2)
+        assert main_window.ui.file_list.currentItem() is not None
+        assert "40785" in main_window.ui.file_list.currentItem().text()
 
-    assert main_window.ui.file_list.currentItem() is not None
-    assert "40782" in main_window.ui.file_list.currentItem().text()
-
-    # Switch to the first run in tab 2 (40785) and verify the file list updates
-    data_manager.set_active_data_from_reduction_list(0)
-    handler.active_data_changed()
-
-    assert main_window.ui.file_list.currentItem() is not None
-    assert "40785" in main_window.ui.file_list.currentItem().text()
+        # Switch to the second run in tab 2 (40782) and verify the file list updates
+        main_window.set_active_reduction_data(True, 1)
+        assert main_window.ui.file_list.currentItem() is not None
+        assert "40782" in main_window.ui.file_list.currentItem().text()
 
 
 if __name__ == "__main__":

--- a/test/unit/quicknxs/interfaces/event_handlers/test_main_handler.py
+++ b/test/unit/quicknxs/interfaces/event_handlers/test_main_handler.py
@@ -445,5 +445,129 @@ def test_show_diagnostic(mocker, qtbot):
     mock_update_file_list.assert_called_once()
 
 
+def test_get_tab_index_for_reduction_table(qtbot):
+    """Test that get_tab_index_for_reduction_table returns the correct tab index for each table widget."""
+    main_window = MainWindow()
+    handler = MainHandler(main_window)
+    data_tab_widget = main_window.ui.tabWidget
+    qtbot.addWidget(main_window)
+
+    main_data_table = data_tab_widget.widget(handler.MAIN_DATA_TAB_INDEX).findChild(QtWidgets.QTableWidget)
+
+    # With only the default tabs, the main data table should map to MAIN_DATA_TAB_INDEX
+    assert handler.get_tab_index_for_reduction_table(main_data_table) == handler.MAIN_DATA_TAB_INDEX
+
+    # Add a second data tab and verify each table maps to the correct index
+    main_window.addDataTable()
+    second_tab_index = 2
+    second_data_table = data_tab_widget.widget(second_tab_index).findChild(QtWidgets.QTableWidget)
+
+    assert handler.get_tab_index_for_reduction_table(main_data_table) == handler.MAIN_DATA_TAB_INDEX
+    assert handler.get_tab_index_for_reduction_table(second_data_table) == second_tab_index
+
+
+@pytest.mark.datarepo
+def test_active_data_changed_syncs_file_list_from_reduction_table(qtbot):
+    """Test that switching the active run in the reduction table updates the file list selection."""
+    main_window = MainWindow()
+    data_manager = main_window.data_manager
+    qtbot.addWidget(main_window)
+
+    # Add two data runs to the reduction table (row 0 = run 40785, row 1 = run 40782)
+    ui_utilities.setText(main_window.numberSearchEntry, str(40785), press_enter=True)
+    ui_utilities.set_current_file_by_run_number(main_window, 40785)
+    main_window.actionAddRefl.triggered.emit()
+    ui_utilities.set_current_file_by_run_number(main_window, 40782)
+    main_window.actionAddRefl.triggered.emit()
+
+    assert main_window.ui.reductionTable.rowCount() == 2
+
+    # Switch active run to row 0 and verify the file list highlights run 40785
+    main_window.set_active_reduction_data(True, 0)
+    assert data_manager._nexus_data == data_manager.reduction_list[0]
+    assert main_window.ui.file_list.currentItem() is not None
+    assert "40785" in main_window.ui.file_list.currentItem().text()
+
+    # Switch active run to row 1 and verify the file list highlights run 40782
+    main_window.set_active_reduction_data(True, 1)
+    assert data_manager._nexus_data == data_manager.reduction_list[1]
+    assert main_window.ui.file_list.currentItem() is not None
+    assert "40782" in main_window.ui.file_list.currentItem().text()
+
+
+@pytest.mark.datarepo
+def test_active_data_changed_syncs_file_list_from_direct_beam_table(qtbot):
+    """Test that switching the active run in the direct beam table updates the file list selection."""
+    main_window = MainWindow()
+    data_manager = main_window.data_manager
+    qtbot.addWidget(main_window)
+
+    # Add a direct beam run and a data run
+    ui_utilities.setText(main_window.numberSearchEntry, str(40786), press_enter=True)
+    ui_utilities.set_current_file_by_run_number(main_window, 40786)
+    main_window.actionAddDirectBeam.triggered.emit()
+    ui_utilities.set_current_file_by_run_number(main_window, 40785)
+    main_window.actionAddRefl.triggered.emit()
+
+    assert main_window.ui.directBeamTable.rowCount() == 1
+    assert main_window.ui.reductionTable.rowCount() == 1
+
+    # The data run should be active initially; verify file list reflects it
+    assert data_manager._nexus_data == data_manager.reduction_list[0]
+    assert main_window.ui.file_list.currentItem() is not None
+    assert "40785" in main_window.ui.file_list.currentItem().text()
+
+    # Switch active to the direct beam run and verify the file list updates
+    main_window.set_active_direct_beam(True, 0)
+    assert data_manager._nexus_data == data_manager.direct_beam_list[0]
+    assert main_window.ui.file_list.currentItem() is not None
+    assert "40786" in main_window.ui.file_list.currentItem().text()
+
+    # Switch back to the data run and verify the file list updates again
+    main_window.set_active_reduction_data(True, 0)
+    assert data_manager._nexus_data == data_manager.reduction_list[0]
+    assert main_window.ui.file_list.currentItem() is not None
+    assert "40785" in main_window.ui.file_list.currentItem().text()
+
+
+@pytest.mark.datarepo
+def test_active_data_changed_syncs_file_list_with_multiple_data_tabs(qtbot):
+    """Test that the file list syncs correctly when the active data comes from a secondary reduction tab.
+
+    Switching the active reduction list to tab 2 and calling active_data_changed() directly
+    verifies the file list sync without triggering the full tab-change event cycle.
+    """
+    main_window = MainWindow()
+    handler = MainHandler(main_window)
+    data_manager = main_window.data_manager
+    qtbot.addWidget(main_window)
+
+    # Add two data runs to the first reduction tab
+    ui_utilities.setText(main_window.numberSearchEntry, str(40785), press_enter=True)
+    ui_utilities.set_current_file_by_run_number(main_window, 40785)
+    main_window.actionAddRefl.triggered.emit()
+    ui_utilities.set_current_file_by_run_number(main_window, 40782)
+    main_window.actionAddRefl.triggered.emit()
+
+    # Add a second data tab (the runs from tab 1 are copied into it)
+    main_window.addDataTable()
+    assert len(data_manager.peak_reduction_lists[2]) == 2
+
+    # Make the second tab the active list and select its second run (40782)
+    data_manager.set_active_reduction_list_index(2)
+    data_manager.set_active_data_from_reduction_list(1)
+    handler.active_data_changed()
+
+    assert main_window.ui.file_list.currentItem() is not None
+    assert "40782" in main_window.ui.file_list.currentItem().text()
+
+    # Switch to the first run in tab 2 (40785) and verify the file list updates
+    data_manager.set_active_data_from_reduction_list(0)
+    handler.active_data_changed()
+
+    assert main_window.ui.file_list.currentItem() is not None
+    assert "40785" in main_window.ui.file_list.currentItem().text()
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/test/unit/quicknxs/interfaces/event_handlers/test_update_file_list.py
+++ b/test/unit/quicknxs/interfaces/event_handlers/test_update_file_list.py
@@ -1,0 +1,428 @@
+"""Unit tests for MainHandler.update_file_list."""
+
+from qtpy import QtWidgets
+
+from quicknxs.interfaces.event_handlers.main_handler import MainHandler
+from quicknxs.interfaces.main_window import MainWindow
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_handler(qtbot, tmp_path):
+    """
+    Create instances of MainWindow and MainHandler.
+
+    Create a MainWindow + MainHandler pair wired to *tmp_path* as the
+    current directory and register the window with qtbot for cleanup.
+    """
+    window = MainWindow()
+    qtbot.addWidget(window)
+    handler = MainHandler(window)
+    handler._data_manager.current_directory = str(tmp_path)
+    return window, handler
+
+
+def _files_in_list(handler):
+    """Return the texts of all items currently in the ui.file_list widget."""
+    widget = handler.ui.file_list
+    return [widget.item(i).text() for i in range(widget.count())]
+
+
+def _add_to_file_list(handler, names):
+    """Directly populate the ui.file_list widget with *names*."""
+    for name in names:
+        QtWidgets.QListWidgetItem(name, handler.ui.file_list)
+
+
+# ---------------------------------------------------------------------------
+# Use-case 1: query_path is None
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateFileListNoQueryPath:
+    """Use case 1: update triggered by directory watcher (no query_path)."""
+
+    def test_populates_list_with_event_files(self, qtbot, tmp_path, mocker):
+        """File list is built from current_event_files when query_path is None."""
+        _, handler = _make_handler(qtbot, tmp_path)
+        mocker.patch.object(
+            type(handler._data_manager),
+            "current_event_files",
+            new_callable=lambda: property(lambda _: ["REF_M_001.nxs.h5", "REF_M_002.nxs.h5"]),
+        )
+
+        handler.update_file_list()
+
+        assert _files_in_list(handler) == ["REF_M_001.nxs.h5", "REF_M_002.nxs.h5"]
+
+    def test_preserves_composite_files_from_widget(self, qtbot, tmp_path, mocker):
+        """Composite file entries already in the list are preserved after refresh."""
+        _, handler = _make_handler(qtbot, tmp_path)
+        composite = "REF_M_001.nxs.h5+REF_M_002.nxs.h5"
+        _add_to_file_list(handler, [composite])
+
+        mocker.patch.object(
+            type(handler._data_manager),
+            "current_event_files",
+            new_callable=lambda: property(lambda _: ["REF_M_001.nxs.h5", "REF_M_002.nxs.h5"]),
+        )
+
+        handler.update_file_list()
+
+        listed = _files_in_list(handler)
+        assert composite in listed
+
+    def test_list_is_sorted(self, qtbot, tmp_path, mocker):
+        """File list is sorted after refresh."""
+        _, handler = _make_handler(qtbot, tmp_path)
+        mocker.patch.object(
+            type(handler._data_manager),
+            "current_event_files",
+            new_callable=lambda: property(lambda _: ["REF_M_003.nxs.h5", "REF_M_001.nxs.h5", "REF_M_002.nxs.h5"]),
+        )
+
+        handler.update_file_list()
+
+        assert _files_in_list(handler) == sorted(["REF_M_001.nxs.h5", "REF_M_002.nxs.h5", "REF_M_003.nxs.h5"])
+
+    def test_current_file_is_selected(self, qtbot, tmp_path, mocker):
+        """The item matching current_file_name is set as the current item."""
+        _, handler = _make_handler(qtbot, tmp_path)
+        mocker.patch.object(
+            type(handler._data_manager),
+            "current_event_files",
+            new_callable=lambda: property(lambda _: ["REF_M_001.nxs.h5", "REF_M_002.nxs.h5"]),
+        )
+        handler._data_manager._current_file_name_for_test = "REF_M_001.nxs.h5"
+        mocker.patch.object(
+            type(handler._data_manager),
+            "current_file_name",
+            new_callable=lambda: property(lambda self: self._current_file_name_for_test),
+        )
+
+        handler.update_file_list()
+
+        current = handler.ui.file_list.currentItem()
+        assert current is not None
+        assert current.text() == "REF_M_001.nxs.h5"
+
+    def test_bad_files_colored_red(self, qtbot, tmp_path, mocker):
+        """Items in bad_files are colored red."""
+        from quicknxs.config.gui import QColors
+
+        _, handler = _make_handler(qtbot, tmp_path)
+        mocker.patch.object(
+            type(handler._data_manager),
+            "current_event_files",
+            new_callable=lambda: property(lambda _: ["REF_M_001.nxs.h5", "REF_M_002.nxs.h5"]),
+        )
+        handler._data_manager.bad_files = {"REF_M_002.nxs.h5"}
+
+        handler.update_file_list()
+
+        widget = handler.ui.file_list
+        items = {widget.item(i).text(): widget.item(i) for i in range(widget.count())}
+        assert items["REF_M_002.nxs.h5"].foreground().color() == QColors.red
+        # The good file is not red
+        assert items["REF_M_001.nxs.h5"].foreground().color() != QColors.red
+
+    def test_empty_directory_clears_list(self, qtbot, tmp_path, mocker):
+        """An empty directory results in an empty file list."""
+        _, handler = _make_handler(qtbot, tmp_path)
+        _add_to_file_list(handler, ["REF_M_old.nxs.h5"])
+        mocker.patch.object(
+            type(handler._data_manager),
+            "current_event_files",
+            new_callable=lambda: property(lambda _: []),
+        )
+
+        handler.update_file_list()
+
+        assert _files_in_list(handler) == []
+
+
+# ---------------------------------------------------------------------------
+# Use-case 2: composite query_path (Open Sum)
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateFileListCompositeQueryPath:
+    """Use case 2: query_path is a composite ('+'-joined) file path."""
+
+    def test_composite_same_directory_adds_composite_to_list(self, qtbot, tmp_path, mocker):
+        """Composite in the current directory: composite basename is appended and list is sorted."""
+        _, handler = _make_handler(qtbot, tmp_path)
+        mocker.patch.object(
+            type(handler._data_manager),
+            "current_event_files",
+            new_callable=lambda: property(lambda _: ["REF_M_001.nxs.h5", "REF_M_002.nxs.h5"]),
+        )
+
+        composite_path = str(tmp_path / "REF_M_001.nxs.h5") + "+" + str(tmp_path / "REF_M_002.nxs.h5")
+        handler.update_file_list(composite_path)
+
+        listed = _files_in_list(handler)
+        assert "REF_M_001.nxs.h5+REF_M_002.nxs.h5" in listed
+        # Single files are also present
+        assert "REF_M_001.nxs.h5" in listed
+        assert "REF_M_002.nxs.h5" in listed
+        # The list is sorted
+        assert listed == sorted(listed)
+
+    def test_composite_new_directory_updates_current_directory(self, qtbot, tmp_path, mocker):
+        """Composite in a new directory: current_directory is updated."""
+        new_dir = tmp_path / "new_subdir"
+        new_dir.mkdir()
+        _, handler = _make_handler(qtbot, tmp_path)
+        mocker.patch.object(
+            type(handler._data_manager),
+            "current_event_files",
+            new_callable=lambda: property(lambda _: ["REF_M_010.nxs.h5"]),
+        )
+        mock_settings = mocker.MagicMock()
+        handler.main_window.settings = mock_settings
+
+        composite_path = str(new_dir / "REF_M_010.nxs.h5") + "+" + str(new_dir / "REF_M_011.nxs.h5")
+        # Create the files so FilePath validates them
+        (new_dir / "REF_M_010.nxs.h5").touch()
+        (new_dir / "REF_M_011.nxs.h5").touch()
+
+        handler.update_file_list(composite_path)
+
+        assert handler._data_manager.current_directory == str(new_dir)
+
+    def test_composite_new_directory_saves_setting(self, qtbot, tmp_path, mocker):
+        """Composite in a new directory: 'current_directory' setting is persisted."""
+        new_dir = tmp_path / "another_dir"
+        new_dir.mkdir()
+        (new_dir / "REF_M_020.nxs.h5").touch()
+        (new_dir / "REF_M_021.nxs.h5").touch()
+
+        _, handler = _make_handler(qtbot, tmp_path)
+        mocker.patch.object(
+            type(handler._data_manager),
+            "current_event_files",
+            new_callable=lambda: property(lambda _: ["REF_M_020.nxs.h5", "REF_M_021.nxs.h5"]),
+        )
+        mock_settings = mocker.MagicMock()
+        handler.main_window.settings = mock_settings
+
+        composite_path = str(new_dir / "REF_M_020.nxs.h5") + "+" + str(new_dir / "REF_M_021.nxs.h5")
+        handler.update_file_list(composite_path)
+
+        mock_settings.setValue.assert_called_once_with("current_directory", str(new_dir))
+
+    def test_composite_path_watcher_updated(self, qtbot, tmp_path, mocker):
+        """Path watcher removes old directory and adds new directory."""
+        new_dir = tmp_path / "watch_dir"
+        new_dir.mkdir()
+        (new_dir / "REF_M_040.nxs.h5").touch()
+        (new_dir / "REF_M_041.nxs.h5").touch()
+
+        _, handler = _make_handler(qtbot, tmp_path)
+        mocker.patch.object(
+            type(handler._data_manager),
+            "current_event_files",
+            new_callable=lambda: property(lambda _: []),
+        )
+        mock_settings = mocker.MagicMock()
+        handler.main_window.settings = mock_settings
+        remove_spy = mocker.spy(handler._path_watcher, "removePath")
+        add_spy = mocker.spy(handler._path_watcher, "addPath")
+
+        composite_path = str(new_dir / "REF_M_040.nxs.h5") + "+" + str(new_dir / "REF_M_041.nxs.h5")
+        handler.update_file_list(composite_path)
+
+        remove_spy.assert_called_once_with(str(tmp_path))
+        add_spy.assert_called_once_with(str(new_dir))
+
+
+# ---------------------------------------------------------------------------
+# Use-case 3.1: single path pointing to a directory
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateFileListDirectoryQueryPath:
+    """Use case 3.1: query_path is a path to a directory."""
+
+    def test_new_directory_populates_list_with_event_files(self, qtbot, tmp_path, mocker):
+        """After switching to a new directory, list is populated with its event files."""
+        new_dir = tmp_path / "subdir2"
+        new_dir.mkdir()
+
+        _, handler = _make_handler(qtbot, tmp_path)
+        mocker.patch.object(
+            type(handler._data_manager),
+            "current_event_files",
+            new_callable=lambda: property(lambda _: ["REF_M_200.nxs.h5", "REF_M_201.nxs.h5"]),
+        )
+        mock_settings = mocker.MagicMock()
+        handler.main_window.settings = mock_settings
+
+        handler.update_file_list(str(new_dir))
+
+        assert handler._data_manager.current_directory == str(new_dir)
+        assert _files_in_list(handler) == ["REF_M_200.nxs.h5", "REF_M_201.nxs.h5"]
+
+    def test_same_directory_leaves_list_unchanged(self, qtbot, tmp_path, mocker):
+        """Pointing to the current directory (same dir) does not reset the file list."""
+        _, handler = _make_handler(qtbot, tmp_path)
+        _add_to_file_list(handler, ["REF_M_300.nxs.h5"])
+        # current_event_files would normally be called — spy to confirm it is not
+        event_files_spy = mocker.patch.object(
+            type(handler._data_manager),
+            "current_event_files",
+            new_callable=lambda: property(lambda _: ["REF_M_300.nxs.h5"]),
+        )
+
+        handler.update_file_list(str(tmp_path))  # Same as current directory
+
+        # new_list is None for the same-dir case, so file_list is NOT cleared
+        assert _files_in_list(handler) == ["REF_M_300.nxs.h5"]
+
+    def test_new_directory_path_watcher_updated(self, qtbot, tmp_path, mocker):
+        """Path watcher is updated when directory changes."""
+        new_dir = tmp_path / "watched_new"
+        new_dir.mkdir()
+
+        _, handler = _make_handler(qtbot, tmp_path)
+        mocker.patch.object(
+            type(handler._data_manager),
+            "current_event_files",
+            new_callable=lambda: property(lambda _: []),
+        )
+        mock_settings = mocker.MagicMock()
+        handler.main_window.settings = mock_settings
+        remove_spy = mocker.spy(handler._path_watcher, "removePath")
+        add_spy = mocker.spy(handler._path_watcher, "addPath")
+
+        handler.update_file_list(str(new_dir))
+
+        remove_spy.assert_called_once_with(str(tmp_path))
+        add_spy.assert_called_once_with(str(new_dir))
+
+
+# ---------------------------------------------------------------------------
+# Use-case 3.2: single path pointing to a file
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateFileListFileQueryPath:
+    """Use case 3.2: query_path is a path to a single file."""
+
+    def test_file_in_current_directory_refreshes_list(self, qtbot, tmp_path, mocker):
+        """A file path in the current directory refreshes the list from current_event_files."""
+        test_file = tmp_path / "REF_M_400.nxs.h5"
+        test_file.touch()
+
+        _, handler = _make_handler(qtbot, tmp_path)
+        mocker.patch.object(
+            type(handler._data_manager),
+            "current_event_files",
+            new_callable=lambda: property(lambda _: ["REF_M_400.nxs.h5", "REF_M_401.nxs.h5"]),
+        )
+
+        handler.update_file_list(str(test_file))
+
+        assert _files_in_list(handler) == ["REF_M_400.nxs.h5", "REF_M_401.nxs.h5"]
+
+    def test_file_in_current_directory_does_not_change_directory(self, qtbot, tmp_path, mocker):
+        """A file in the current directory does not change current_directory."""
+        test_file = tmp_path / "REF_M_402.nxs.h5"
+        test_file.touch()
+
+        _, handler = _make_handler(qtbot, tmp_path)
+        mocker.patch.object(
+            type(handler._data_manager),
+            "current_event_files",
+            new_callable=lambda: property(lambda _: ["REF_M_402.nxs.h5"]),
+        )
+
+        original_dir = handler._data_manager.current_directory
+        handler.update_file_list(str(test_file))
+
+        assert handler._data_manager.current_directory == original_dir
+
+    def test_file_in_new_directory_updates_current_directory(self, qtbot, tmp_path, mocker):
+        """A file path in a new directory triggers a directory switch."""
+        new_dir = tmp_path / "new_data"
+        new_dir.mkdir()
+        test_file = new_dir / "REF_M_500.nxs.h5"
+        test_file.touch()
+
+        _, handler = _make_handler(qtbot, tmp_path)
+        mocker.patch.object(
+            type(handler._data_manager),
+            "current_event_files",
+            new_callable=lambda: property(lambda _: ["REF_M_500.nxs.h5"]),
+        )
+        mock_settings = mocker.MagicMock()
+        handler.main_window.settings = mock_settings
+
+        handler.update_file_list(str(test_file))
+
+        assert handler._data_manager.current_directory == str(new_dir)
+
+    def test_file_in_new_directory_populates_list(self, qtbot, tmp_path, mocker):
+        """After a directory switch via file path, list is populated with event files."""
+        new_dir = tmp_path / "another_data"
+        new_dir.mkdir()
+        test_file = new_dir / "REF_M_600.nxs.h5"
+        test_file.touch()
+
+        _, handler = _make_handler(qtbot, tmp_path)
+        mocker.patch.object(
+            type(handler._data_manager),
+            "current_event_files",
+            new_callable=lambda: property(lambda _: ["REF_M_600.nxs.h5", "REF_M_601.nxs.h5"]),
+        )
+        mock_settings = mocker.MagicMock()
+        handler.main_window.settings = mock_settings
+
+        handler.update_file_list(str(test_file))
+
+        assert _files_in_list(handler) == ["REF_M_600.nxs.h5", "REF_M_601.nxs.h5"]
+
+    def test_file_in_new_directory_path_watcher_updated(self, qtbot, tmp_path, mocker):
+        """Path watcher is updated when directory changes via a file path."""
+        new_dir = tmp_path / "watch_file_dir"
+        new_dir.mkdir()
+        test_file = new_dir / "REF_M_700.nxs.h5"
+        test_file.touch()
+
+        _, handler = _make_handler(qtbot, tmp_path)
+        mocker.patch.object(
+            type(handler._data_manager),
+            "current_event_files",
+            new_callable=lambda: property(lambda _: []),
+        )
+        mock_settings = mocker.MagicMock()
+        handler.main_window.settings = mock_settings
+        remove_spy = mocker.spy(handler._path_watcher, "removePath")
+        add_spy = mocker.spy(handler._path_watcher, "addPath")
+
+        handler.update_file_list(str(test_file))
+
+        remove_spy.assert_called_once_with(str(tmp_path))
+        add_spy.assert_called_once_with(str(new_dir))
+
+    def test_file_in_current_directory_preserves_composites(self, qtbot, tmp_path, mocker):
+        """Refreshing via a same-directory file path preserves composite entries in the list."""
+        test_file = tmp_path / "REF_M_800.nxs.h5"
+        test_file.touch()
+        composite = "REF_M_800.nxs.h5+REF_M_801.nxs.h5"
+
+        _, handler = _make_handler(qtbot, tmp_path)
+        _add_to_file_list(handler, [composite])
+
+        mocker.patch.object(
+            type(handler._data_manager),
+            "current_event_files",
+            new_callable=lambda: property(lambda _: ["REF_M_800.nxs.h5", "REF_M_801.nxs.h5"]),
+        )
+
+        handler.update_file_list(str(test_file))
+
+        assert composite in _files_in_list(handler)


### PR DESCRIPTION
## Description of work:

There are two ways to select the active run: in the file list or in the reduction or direct beam table. The active run shown in either widget was whichever was selected last _in that widget_, but this could lead to one run being "active" (highlighted) in the file list and another run being "active" in the reduction table ("Active" radio button selected).

This PR changes the active run handling to keep the active run in sync between the file list and the currently visible tab (direct beam or one of the data tabs).

Check all that apply:
(if not, provide an explanation in the work description)
- [ ] updated documentation and checked that it looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests

**References:**
- Links to IBM EWM items: [Defect 14846: [QuickNXS] Mismatch in active run between file list and data tab](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=14846)
- Links to related issues or pull requests:


# :warning: Manual test for the reviewer
([instructions to set up the environment](https://reflectivity-ui.readthedocs.io/en/latest/developer/environment.html))

Load data in the direct beam and reduction tables and verify that the active radio button and the file list stay in sync whether a run is selected from the file list or one of the tables.

# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date and looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] code comments added when explaining intent
