### PR TITLE
Use timestamp in dev versions

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -4333,8 +4333,8 @@ packages:
   timestamp: 1743692373820
 - pypi: ./
   name: quicknxs
-  version: 4.16.0rc3
-  sha256: 34400361493d915d0f4e77f3d3bdf12fa728fb31f9df51f09c64e363321a2314
+  version: 4.17.0.dev20260325150228
+  sha256: aa2e7815eb899cedc4e1c3774fa4e0c618b88dd0624bb8f1a65c0261d4dbd961
   requires_python: '>=3.10,<3.13'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/rapidjson-1.1.0.post20240409-h3f2d84a_2.conda
   sha256: f87f265263a1ddbc50b98e2c2bcaa2bac63da3acc09267815dd0f4bd614cd902

--- a/pixi.lock
+++ b/pixi.lock
@@ -9,6 +9,8 @@ environments:
     - url: https://prefix.dev/pixi-build-backends/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -4331,10 +4333,9 @@ packages:
   timestamp: 1743692373820
 - pypi: ./
   name: quicknxs
-  version: 4.16.0.dev26
-  sha256: bc3379a515b7b22f99278a185603e257d5756d2eeeb909cd3c92386218521daf
+  version: 4.16.0rc3
+  sha256: 34400361493d915d0f4e77f3d3bdf12fa728fb31f9df51f09c64e363321a2314
   requires_python: '>=3.10,<3.13'
-  editable: true
 - conda: https://conda.anaconda.org/conda-forge/linux-64/rapidjson-1.1.0.post20240409-h3f2d84a_2.conda
   sha256: f87f265263a1ddbc50b98e2c2bcaa2bac63da3acc09267815dd0f4bd614cd902
   md5: 65e2f30d532b4ae2063a424c185cc678

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,15 +43,14 @@ packages = ["src/quicknxs"]
 [tool.versioningit.vcs]
 method = "git"
 default-tag = "4.0.0"
-exclude = ["*rc*"]
 
 [tool.versioningit.next-version]
 method = "minor"
 
 [tool.versioningit.format]
-distance = "{next_version}.dev{distance}"
+distance = "{next_version}.dev{committer_date:%Y%m%d%H%M%S}"
 dirty = "{version}"
-distance-dirty = "{next_version}.dev{distance}"
+distance-dirty = "{next_version}.dev{committer_date:%Y%m%d%H%M%S}"
 
 [tool.versioningit.write]
 file = "src/quicknxs/_version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,7 +171,7 @@ conda-publish = { cmd = "anaconda upload *.conda", description = "Publish the .c
     "conda-build",
 ] }
 # Misc
-audit-deps = { cmd = "pip-audit --local --ignore-vuln CVE-2026-32597 --ignore-vuln CVE-2026-31958 --ignore-vuln GHSA-78cv-mqj4-43f7", description = "Audit the package dependencies for vulnerabilities (ignoring conda package version lags)" }
+audit-deps = { cmd = "pip-audit --local --ignore-vuln CVE-2026-32597 --ignore-vuln CVE-2026-31958 --ignore-vuln GHSA-78cv-mqj4-43f7 --ignore-vuln CVE-2026-4539", description = "Audit the package dependencies for vulnerabilities (ignoring conda package version lags)" }
 clean = { cmd = 'rm -rf .pytest_cache .ruff_cache **/*.egg-info **/dist **/__pycache__ **/_version.py', description = "Clean up various caches and build artifacts" }
 clean-conda = { cmd = "rm -f *.conda", description = "Clean the local .conda build artifacts" }
 clean-docs = { cmd = "rm -rf docs/_build", description = "Clean up documentation build artifacts" }


### PR DESCRIPTION
## Description of work:

Revert the change to ignore RC version tags in versioningit, since they were also ignored when building RC packages. Instead ensure the dev versions increase monotonically by using _timestamp_ rather than _number of commits_ since the latest tag.

Check all that apply:
(if not, provide an explanation in the work description)
- [ ] updated documentation and checked that it looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests

**References:**
- Links to IBM EWM items:
- Links to related issues or pull requests:


# :warning: Manual test for the reviewer
([instructions to set up the environment](https://reflectivity-ui.readthedocs.io/en/latest/developer/environment.html))

# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date and looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] code comments added when explaining intent
