### PR TITLE
Rewrite save_data() to support all plot types and export formats

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -16,8 +16,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/alabaster-1.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.15.3-hb03c661_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/anaconda-auth-0.14.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/anaconda-cli-base-0.8.1-pyhc364b38_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anaconda-auth-0.14.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anaconda-cli-base-0.8.2-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anaconda-client-1.14.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
@@ -42,16 +42,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.2.25-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.0.0-py311h03d9500_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.5.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/check-wheel-contents-0.6.3-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.1-pyh8f84b5b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.2-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/codecov-2.1.13-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/conda-package-handling-2.4.0-pyh7900ff3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/conda-package-streaming-0.12.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.3-py311h724c32c_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.13.5-py311h3778330_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-46.0.5-py311h2005dd1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-46.0.7-py311h2005dd1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cyclonedx-python-lib-11.7.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cyrus-sasl-2.1.28-hac629b4_1.conda
@@ -87,8 +87,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gunicorn-25.3.0-py311h38be061_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.16.0-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.16.0-nompi_py311h0b2f468_101.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-13.2.1-h6083320_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.16.0-nompi_py311h0b2f468_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.1.0-h6083320_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.6-nompi_h19486de_108.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
@@ -137,8 +137,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.77-hd0affe5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-6_h0358290_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp21.1-21.1.8-default_h99862b1_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp22.1-22.1.0-default_h99862b1_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-22.1.0-default_h746c552_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp22.1-22.1.3-default_h99862b1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-22.1.3-default_h746c552_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.19.0-hcf29cc6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-h17f619e_0.conda
@@ -167,8 +167,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.2-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-6_h47877c9_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm21-21.1.8-hf7376ad_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm22-22.1.2-hf7376ad_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.2-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm22-22.1.3-hf7376ad_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libntlm-1.8-hb9d3cd8_0.conda
@@ -177,18 +177,18 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.6.1-h280c20c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.56-h421ea60_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.57-h421ea60_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-18.3-h9abb657_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libraw-0.21.5-h074291d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/librdkafka-2.11.1-hdd48ec7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc7d488a_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.52.0-hf4e2dac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.0-hf4e2dac_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.13-hd0affe5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.1-h9d88235_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.3-h5347b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libvorbis-1.3.7-h54a6638_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libvulkan-loader-1.4.341.0-h5279c79_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
@@ -207,13 +207,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.9.4-py311h38be061_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.9.4-py311h2b939e6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.8.0-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-11.0.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.32.9-hc50e24c_0.conda
       - conda: https://conda.anaconda.org/neutrons/noarch/mr_reduction-2.17.0-pyh4616a5c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.1.2-py311hdf67eae_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/muparser-2.3.4-h27087fc_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.18.1-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.19.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.10.0-pyhd8ed1ab_0.conda
@@ -222,18 +222,18 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.1.3-py311h71ddf71_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/oauthlib-3.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/occt-7.9.2-novtk_hac3f730_103.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openexr-3.4.8-h40f6f1d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openexr-3.4.9-h40f6f1d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openjph-0.26.3-h8d634f6_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.10-hbde042b_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.13-hbde042b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/orsopy-1.2.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packageurl-python-0.17.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-3.0.1-py311h8032f78_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-3.0.2-py311h8032f78_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.4-hda50119_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.1.1-py311hf88fc01_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.2.0-py311hf88fc01_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pint-0.25.3-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.0.1-pyh8b19718_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-api-0.0.34-pyhd8ed1ab_0.conda
@@ -241,7 +241,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-requirements-parser-32.0.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkce-1.0.3-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/neutrons/noarch/plot-publisher-1.4.0-pyhbf21a9e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/plotly-6.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
@@ -263,16 +263,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyqt-5.15.11-py311h0580839_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyqt5-sip-12.17.0-py311h1ddb823_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.11.0-py311hf27b23e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.11.0-py311hf27b23e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-mock-3.15.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-qt-4.5.0-pyhdecd6ff_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xvfb-3.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.15-hd63d673_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-discovery-1.2.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-discovery-1.2.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.2.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.2-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.11-8_cp311.conda
@@ -286,7 +286,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/quasielasticbayes-0.3.0-py311h7bc6544_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/quickbayes-1.0.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rapidjson-1.1.0.post20240409-h3f2d84a_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/readchar-4.2.1-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/readchar-4.2.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.37.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
@@ -296,7 +296,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/roman-numerals-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/roman-numerals-py-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.30.0-py311h902ca64_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.15.8-h7805a7d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.15.10-h7805a7d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.17.1-py311hbe70eeb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/secretstorage-3.4.1-py311h38be061_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/seekpath-2.1.0-pyhd8ed1ab_2.conda
@@ -329,7 +329,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.5-py311h49ec1c0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.24.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.24.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
@@ -339,11 +339,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/unixodbc-2.3.14-h69e2008_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/versioningit-3.3.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-21.2.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-21.2.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.25.0-hd6090a7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/werkzeug-3.1.7-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/werkzeug-3.1.8-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.46.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-filename-1.4.2-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.1-h4f16b4b_2.conda
@@ -377,7 +377,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.25.0-py311haee01d2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - pypi: https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/e7/26/46673bb18448c51222c6272c850484a0092f364fae8d0315be9aa1e4baa7/regex-2026.3.32-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/01/ea/4c8d306e9c36ac22417336b1e02e7b358152c34dc379673f2d331143725f/regex-2026.4.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/1a/75/9f020e662bfe50213dfb81f42afc0a02be3dcb566e6212288ba3da3d031a/sphinx_qt_documentation-0.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d2/b8/f0b9b880c03a3db8eaff63d76ca751ac7d8e45483fb7a0bb9f8e5c6ce433/toml_cli-0.8.2-py3-none-any.whl
       - pypi: ./
@@ -418,9 +418,9 @@ packages:
   purls: []
   size: 584660
   timestamp: 1768327524772
-- conda: https://conda.anaconda.org/conda-forge/noarch/anaconda-auth-0.14.0-pyhd8ed1ab_0.conda
-  sha256: 402e5433ecc3d3ae06a9b43c3e45e769de86985ffd60e8355190802bba7ca3bb
-  md5: a60066d23ca609efbb14ada3e57fa98c
+- conda: https://conda.anaconda.org/conda-forge/noarch/anaconda-auth-0.14.1-pyhd8ed1ab_0.conda
+  sha256: d74184b93673483bbcee5319927ad522f059f291a0f1f2b00e8bff0badd995e2
+  md5: 18b8082600565ab922555ce01b785dc1
   depends:
   - anaconda-cli-base >=0.8.1
   - cryptography >=3.4.0
@@ -434,18 +434,18 @@ packages:
   - requests
   - semver <4
   constrains:
-  - conda >=23.9.0
-  - conda-token >=0.7.0
   - anaconda-cloud-auth >=0.8
+  - conda-token >=0.7.0
+  - conda >=23.9.0
   license: BSD-3-Clause
   license_family: BSD
   purls:
   - pkg:pypi/anaconda-auth?source=hash-mapping
-  size: 52672
-  timestamp: 1774323340657
-- conda: https://conda.anaconda.org/conda-forge/noarch/anaconda-cli-base-0.8.1-pyhc364b38_1.conda
-  sha256: 6ba3551f9085546106b23b980c8a71b884bf580c9a03245c0d3fa7fbff44c479
-  md5: 7c77aad42e8687238c52e72b4ecf09b0
+  size: 53051
+  timestamp: 1775655411614
+- conda: https://conda.anaconda.org/conda-forge/noarch/anaconda-cli-base-0.8.2-pyhc364b38_0.conda
+  sha256: a15e57650690f37bbe54f18e4ff429530b3bb54aa582ff9e3a9155921fec2804
+  md5: af12e48f4d16dce2d160e3067930ad93
   depends:
   - python >=3.10
   - click
@@ -466,8 +466,8 @@ packages:
   license_family: BSD
   purls:
   - pkg:pypi/anaconda-cli-base?source=hash-mapping
-  size: 29565
-  timestamp: 1772639433841
+  size: 29631
+  timestamp: 1775090496005
 - conda: https://conda.anaconda.org/conda-forge/noarch/anaconda-client-1.14.1-pyhcf101f3_0.conda
   sha256: 15f36a27ba72fcce0cc19023d55c2bc23cfa78940622df8e0d8d75c6c14b671a
   md5: 69a7f22cff99ab4b87aa2c5b729b00f8
@@ -799,17 +799,17 @@ packages:
   - pkg:pypi/cfgv?source=hash-mapping
   size: 13589
   timestamp: 1763607964133
-- conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.6-pyhd8ed1ab_0.conda
-  sha256: d86dfd428b2e3c364fa90e07437c8405d635aa4ef54b25ab51d9c712be4112a5
-  md5: 49ee13eb9b8f44d63879c69b8a40a74b
+- conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
+  sha256: 3f9483d62ce24ecd063f8a5a714448445dc8d9e201147c46699fc0033e824457
+  md5: a9167b9571f3baa9d448faa2139d1089
   depends:
   - python >=3.10
   license: MIT
   license_family: MIT
   purls:
   - pkg:pypi/charset-normalizer?source=compressed-mapping
-  size: 58510
-  timestamp: 1773660086450
+  size: 58872
+  timestamp: 1775127203018
 - conda: https://conda.anaconda.org/conda-forge/noarch/check-wheel-contents-0.6.3-pyhcf101f3_0.conda
   sha256: 685d52092d3253113f0e7ef83902dd78bde9fc3a5e33b972517ab053dc0c4ba3
   md5: 150979ee3e79509de3bb2b7fd4157b48
@@ -828,19 +828,19 @@ packages:
   - pkg:pypi/check-wheel-contents?source=hash-mapping
   size: 580700
   timestamp: 1754145812782
-- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.1-pyh8f84b5b_1.conda
-  sha256: 38cfe1ee75b21a8361c8824f5544c3866f303af1762693a178266d7f198e8715
-  md5: ea8a6c3256897cc31263de9f455e25d9
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.2-pyhc90fa1f_0.conda
+  sha256: 526d434cf5390310f40f34ea6ec4f0c225cdf1e419010e624d399b13b2059f0f
+  md5: 4d18bc3af7cfcea97bd817164672a08c
   depends:
-  - python >=3.10
   - __unix
   - python
+  - python >=3.10
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/click?source=hash-mapping
-  size: 97676
-  timestamp: 1764518652276
+  - pkg:pypi/click?source=compressed-mapping
+  size: 98253
+  timestamp: 1775578217828
 - conda: https://conda.anaconda.org/conda-forge/noarch/codecov-2.1.13-pyhd8ed1ab_1.conda
   sha256: 51ead85d30f4eeff41c558b24ab0992a6d9d08af3e887d3ac7d2c169670b807f
   md5: d924fe46139596ebc3d4d424ec39ed51
@@ -922,14 +922,14 @@ packages:
   - pkg:pypi/coverage?source=compressed-mapping
   size: 399687
   timestamp: 1773761044419
-- conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-46.0.5-py311h2005dd1_0.conda
-  sha256: 0b427b0f353ccf66a926360b6544ea18566e13099e661dcd35c61ffc9c0924e9
-  md5: f9c47968555906c9fe918f447d9abf1f
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-46.0.7-py311h2005dd1_0.conda
+  sha256: 4fea148d52c0408970a41aca41a0ea87675cc889f4d0387c21f39d3cf5ee6cde
+  md5: 62b09ad7f1907a1c91dd7226975ce4cd
   depends:
   - __glibc >=2.17,<3.0.a0
   - cffi >=1.14
   - libgcc >=14
-  - openssl >=3.5.5,<4.0a0
+  - openssl >=3.5.6,<4.0a0
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
   constrains:
@@ -938,8 +938,8 @@ packages:
   license_family: BSD
   purls:
   - pkg:pypi/cryptography?source=hash-mapping
-  size: 1714583
-  timestamp: 1770772534804
+  size: 2611406
+  timestamp: 1775637733645
 - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
   sha256: bb47aec5338695ff8efbddbc669064a3b10fe34ad881fb8ad5d64fbfa6910ed1
   md5: 4c2a8fef270f6c69591889b93f9f55c1
@@ -1103,7 +1103,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/flask?source=compressed-mapping
+  - pkg:pypi/flask?source=hash-mapping
   size: 87428
   timestamp: 1771489274528
 - conda: https://conda.anaconda.org/conda-forge/noarch/flexcache-0.3-pyhd8ed1ab_1.conda
@@ -1417,9 +1417,9 @@ packages:
   - pkg:pypi/h2?source=hash-mapping
   size: 95967
   timestamp: 1756364871835
-- conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.16.0-nompi_py311h0b2f468_101.conda
-  sha256: bc6f3f698839e83f594dee629b53c506de3a37595f4571c9b85d7464fe8e23e9
-  md5: 208b162b7be10f8398a88055190900f7
+- conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.16.0-nompi_py311h0b2f468_102.conda
+  sha256: 61e3adb8218d57a2e7a91c7b4b4d338c3c0d23432ef0f2ed5bfc8d51f73735f3
+  md5: f476161e215ecee68daf16efbf209731
   depends:
   - __glibc >=2.17,<3.0.a0
   - cached-property
@@ -1431,20 +1431,20 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/h5py?source=compressed-mapping
-  size: 1356892
-  timestamp: 1774712270994
-- conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-13.2.1-h6083320_0.conda
-  sha256: 477f2c553f72165020d3c56740ba354be916c2f0b76fd9f535e83d698277d5ec
-  md5: 14470902326beee192e33719a2e8bb7f
+  - pkg:pypi/h5py?source=hash-mapping
+  size: 1353682
+  timestamp: 1775581279300
+- conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.1.0-h6083320_0.conda
+  sha256: 22c4f6df7eb4684a4b60e62de84211e7d80a0df2d7cfdbbd093a73650e3f2d45
+  md5: ca8a94b613db5d805c3d2498a7c30997
   depends:
   - __glibc >=2.17,<3.0.a0
   - cairo >=1.18.4,<2.0a0
   - graphite2 >=1.3.14,<2.0a0
   - icu >=78.3,<79.0a0
-  - libexpat >=2.7.4,<3.0a0
-  - libfreetype >=2.14.2
-  - libfreetype6 >=2.14.2
+  - libexpat >=2.7.5,<3.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
   - libgcc >=14
   - libglib >=2.86.4,<3.0a0
   - libstdcxx >=14
@@ -1452,8 +1452,8 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 2384060
-  timestamp: 1774276284520
+  size: 2338203
+  timestamp: 1775569314754
 - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
   sha256: 0d09b6dc1ce5c4005ae1c6a19dc10767932ef9a5e9c755cfdbb5189ac8fb0684
   md5: bd77f8da987968ec3927990495dc22e4
@@ -2093,32 +2093,32 @@ packages:
   purls: []
   size: 21066639
   timestamp: 1770190428756
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp22.1-22.1.0-default_h99862b1_0.conda
-  sha256: 914da94dbf829192b2bb360a7684b32e46f047a57de96a2f5ab39a011aeae6ea
-  md5: d966a23335e090a5410cc4f0dec8d00a
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp22.1-22.1.3-default_h99862b1_0.conda
+  sha256: 83a6477bca1033ebe4ed761e280b94e894bce5b44866c5a790f98f570e8f3487
+  md5: 4642265acfa1ad8dfe96c89d8d7b38fe
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - libllvm22 >=22.1.0,<22.2.0a0
+  - libllvm22 >=22.1.3,<22.2.0a0
   - libstdcxx >=14
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   purls: []
-  size: 21661249
-  timestamp: 1772101075353
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-22.1.0-default_h746c552_0.conda
-  sha256: 4a9dd814492a129f2ff40cd4ab0b942232c9e3c6dbc0d0aaf861f1f65e99cc7d
-  md5: 140459a7413d8f6884eb68205ce39a0d
+  size: 21667487
+  timestamp: 1775789459997
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-22.1.3-default_h746c552_0.conda
+  sha256: 485de0c70865eb489d819defea714187c84502e3c50a511173d62135b8cef12f
+  md5: 9b47a4cd3aabb73201a2b8ed9f127189
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - libllvm22 >=22.1.0,<22.2.0a0
+  - libllvm22 >=22.1.3,<22.2.0a0
   - libstdcxx >=14
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   purls: []
-  size: 12817500
-  timestamp: 1772101411287
+  size: 12822776
+  timestamp: 1775789745068
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
   sha256: 205c4f19550f3647832ec44e35e6d93c8c206782bdd620c1d7cf66237580ff9c
   md5: 49c553b47ff679a6a1e9fc80b9c5a2d4
@@ -2463,9 +2463,9 @@ packages:
   purls: []
   size: 44333366
   timestamp: 1765959132513
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm22-22.1.2-hf7376ad_0.conda
-  sha256: eda0013a9979d142f520747e3621749c493f5fbc8f9d13a52ac7a2b699338e7c
-  md5: 7147b0792a803cd5b9929ce5d48f7818
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm22-22.1.3-hf7376ad_0.conda
+  sha256: ad732019e8dd963efb5a54b5ff49168f191246bc418c3033762b6e8cb64b530c
+  md5: aeb186f7165bf287495a267fa8ff4129
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
@@ -2477,20 +2477,20 @@ packages:
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   purls: []
-  size: 44217146
-  timestamp: 1774480335347
-- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.2-hb03c661_0.conda
-  sha256: 755c55ebab181d678c12e49cced893598f2bab22d582fbbf4d8b83c18be207eb
-  md5: c7c83eecbb72d88b940c249af56c8b17
+  size: 44235531
+  timestamp: 1775641389057
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
+  sha256: ec30e52a3c1bf7d0425380a189d209a52baa03f22fb66dd3eb587acaa765bd6d
+  md5: b88d90cad08e6bc8ad540cb310a761fb
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   constrains:
-  - xz 5.8.2.*
+  - xz 5.8.3.*
   license: 0BSD
   purls: []
-  size: 113207
-  timestamp: 1768752626120
+  size: 113478
+  timestamp: 1775825492909
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
   sha256: 663444d77a42f2265f54fb8b48c5450bfff4388d9c0f8253dd7855f0d993153f
   md5: 2a45e7f8af083626f009645a6481f12d
@@ -2587,17 +2587,17 @@ packages:
   purls: []
   size: 28424
   timestamp: 1749901812541
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.56-h421ea60_0.conda
-  sha256: 4f9fca3bc21e485ec0b3eb88db108b6cf9ab9a481cdf7d2ac6f9d30350b45ead
-  md5: 97169784f0775c85683c3d8badcea2c3
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.57-h421ea60_0.conda
+  sha256: 06323fb0a831440f0b72a53013182e1d4bb219e3ea958bb37af98b25dc0cf518
+  md5: 06f225e6d8c549ad6c0201679828a882
   depends:
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
   - libzlib >=1.3.2,<2.0a0
   license: zlib-acknowledgement
   purls: []
-  size: 317540
-  timestamp: 1774513272700
+  size: 317779
+  timestamp: 1775692841709
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-18.3-h9abb657_0.conda
   sha256: c7e61b86c273ec1ce92c0e087d1a0f3ed3b9485507c6cd35e03bc63de1b6b03f
   md5: 405ec206d230d9d37ad7c2636114cbf4
@@ -2664,18 +2664,18 @@ packages:
   purls: []
   size: 355619
   timestamp: 1765181778282
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.52.0-hf4e2dac_0.conda
-  sha256: d716847b7deca293d2e49ed1c8ab9e4b9e04b9d780aea49a97c26925b28a7993
-  md5: fd893f6a3002a635b5e50ceb9dd2c0f4
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.0-hf4e2dac_0.conda
+  sha256: ec37c79f737933bbac965f5dc0f08ef2790247129a84bb3114fad4900adce401
+  md5: 810d83373448da85c3f673fbcb7ad3a3
   depends:
   - __glibc >=2.17,<3.0.a0
-  - icu >=78.2,<79.0a0
+  - icu >=78.3,<79.0a0
   - libgcc >=14
-  - libzlib >=1.3.1,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
   license: blessing
   purls: []
-  size: 951405
-  timestamp: 1772818874251
+  size: 958864
+  timestamp: 1775753750179
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
   sha256: fa39bfd69228a13e553bd24601332b7cfeb30ca11a3ca50bb028108fe90a7661
   md5: eecce068c7e4eddeb169591baac20ac4
@@ -2741,17 +2741,17 @@ packages:
   purls: []
   size: 435273
   timestamp: 1762022005702
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.3-h5347b49_0.conda
-  sha256: 1a7539cfa7df00714e8943e18de0b06cceef6778e420a5ee3a2a145773758aee
-  md5: db409b7c1720428638e7c0d509d3e1b5
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42-h5347b49_0.conda
+  sha256: bc1b08c92626c91500fd9f26f2c797f3eb153b627d53e9c13cd167f1e12b2829
+  md5: 38ffe67b78c9d4de527be8315e5ada2c
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 40311
-  timestamp: 1766271528534
+  size: 40297
+  timestamp: 1775052476770
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libvorbis-1.3.7-h54a6638_2.conda
   sha256: ca494c99c7e5ecc1b4cd2f72b5584cef3d4ce631d23511184411abcbb90a21a5
   md5: b4ecbefe517ed0157c37f8182768271c
@@ -3055,18 +3055,18 @@ packages:
   - pkg:pypi/mdurl?source=hash-mapping
   size: 14465
   timestamp: 1733255681319
-- conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.8.0-pyhcf101f3_1.conda
-  sha256: 449609f0d250607a300754474350a3b61faf45da183d3071e9720e453c765b8a
-  md5: 32f78e9d06e8593bc4bbf1338da06f5f
+- conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-11.0.2-pyhcf101f3_0.conda
+  sha256: 74f7b461e0f0e0709a0c8abb018de9ad885258b74790ffda1e750ac5ddde0a85
+  md5: b874955758a30a37c78b82ea5cf78fdb
   depends:
   - python >=3.10
   - python
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/more-itertools?source=hash-mapping
-  size: 69210
-  timestamp: 1764487059562
+  - pkg:pypi/more-itertools?source=compressed-mapping
+  size: 71254
+  timestamp: 1775762492525
 - conda: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.32.9-hc50e24c_0.conda
   sha256: 39c4700fb3fbe403a77d8cc27352fa72ba744db487559d5d44bf8411bb4ea200
   md5: c7f302fd11eeb0987a6a5e1f3aed6a21
@@ -3133,9 +3133,9 @@ packages:
   purls: []
   size: 216720
   timestamp: 1668542554576
-- conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.18.1-pyhcf101f3_1.conda
-  sha256: 541fd4390a0687228b8578247f1536a821d9261389a65585af9d1a6f2a14e1e0
-  md5: 30bec5e8f4c3969e2b1bd407c5e52afb
+- conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.19.0-pyhcf101f3_0.conda
+  sha256: cac1f5236e9d7d1d90d733254bb26948b7c1b22cfbaffc6ebad3ebe9435f26b1
+  md5: b94cbc2227cdca1e9a65d7ad4ee636c1
   depends:
   - python >=3.10
   - python
@@ -3143,8 +3143,8 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/narwhals?source=compressed-mapping
-  size: 280459
-  timestamp: 1774380620329
+  size: 281869
+  timestamp: 1775500139138
 - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
   sha256: 7a5bd30a2e7ddd7b85031a5e2e14f290898098dc85bea5b3a5bf147c25122838
   md5: bbe1963f1e47f594070ffe87cdf612ea
@@ -3265,22 +3265,22 @@ packages:
   purls: []
   size: 25389146
   timestamp: 1765174567465
-- conda: https://conda.anaconda.org/conda-forge/linux-64/openexr-3.4.8-h40f6f1d_0.conda
-  sha256: 67cbe0dfa060e03a0abd32daacfcb4c7b861d39fbc5378a394021072e742b4c9
-  md5: 494f0051343d095d4bf99f6fb31fb7cf
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openexr-3.4.9-h40f6f1d_0.conda
+  sha256: 930187c0fa5df54ac504d078f6aac64dfe6b101ca8952cae88d0d3825490d67c
+  md5: c702e499f1a80315ac41df8dd5c785bf
   depends:
-  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
   - openjph >=0.26.3,<0.27.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - libzlib >=1.3.2,<2.0a0
   - imath >=3.2.2,<3.2.3.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libdeflate >=1.25,<1.26.0a0
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 1217976
-  timestamp: 1774561006856
+  size: 1217847
+  timestamp: 1775504236214
 - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
   sha256: 3900f9f2dbbf4129cf3ad6acf4e4b6f7101390b53843591c53b00f034343bc4d
   md5: 11b3379b191f63139e29c0d19dee24cd
@@ -3309,24 +3309,24 @@ packages:
   purls: []
   size: 279846
   timestamp: 1771349499024
-- conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.10-hbde042b_1.conda
-  sha256: 2e185a3dc2bdc4525dd68559efa3f24fa9159a76c40473e320732b35115163b2
-  md5: 3c40a106eadf7c14c6236ceddb267893
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.13-hbde042b_0.conda
+  sha256: 21c4f6c7f41dc9bec2ea2f9c80440d9a4d45a6f2ac13243e658f10dcf1044146
+  md5: 680608784722880fbfe1745067570b00
   depends:
   - __glibc >=2.17,<3.0.a0
   - cyrus-sasl >=2.1.28,<3.0a0
   - krb5 >=1.22.2,<1.23.0a0
   - libgcc >=14
   - libstdcxx >=14
-  - openssl >=3.5.5,<4.0a0
+  - openssl >=3.5.6,<4.0a0
   license: OLDAP-2.8
   license_family: BSD
   purls: []
-  size: 785570
-  timestamp: 1771970256722
-- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
-  sha256: 44c877f8af015332a5d12f5ff0fb20ca32f896526a7d0cdb30c769df1144fb5c
-  md5: f61eb8cd60ff9057122a3d338b99c00f
+  size: 786149
+  timestamp: 1775741359582
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
+  sha256: c0ef482280e38c71a08ad6d71448194b719630345b0c9c60744a2010e8a8e0cb
+  md5: da1b85b6a87e141f5140bb9924cecab0
   depends:
   - __glibc >=2.17,<3.0.a0
   - ca-certificates
@@ -3334,8 +3334,8 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 3164551
-  timestamp: 1769555830639
+  size: 3167099
+  timestamp: 1775587756857
 - conda: https://conda.anaconda.org/conda-forge/noarch/orsopy-1.2.1-pyhd8ed1ab_1.conda
   sha256: ab2e2c8cac273488028874c3eb29064907814c06c2154495584d69353fbd73b8
   md5: 7793211c1838805e0e19af038fa132ab
@@ -3372,18 +3372,18 @@ packages:
   - pkg:pypi/packaging?source=compressed-mapping
   size: 72010
   timestamp: 1769093650580
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-3.0.1-py311h8032f78_0.conda
-  sha256: 3e58067de2e0b8220cf1323c1fc736028b2a117b7a7173bfe67f7da11094271f
-  md5: 3ac73c673df24589b5b84d43a4afd235
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-3.0.2-py311h8032f78_0.conda
+  sha256: f8aefe73a0d0863a92ad09688dbb65b2b746202f93733016c4db671f977c63ab
+  md5: 138e5d98884407fcc8ccc6088574b1c7
   depends:
   - python
   - numpy >=1.26.0
   - python-dateutil >=2.8.2
+  - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - python_abi 3.11.* *_cp311
   - numpy >=1.23,<3
+  - python_abi 3.11.* *_cp311
   constrains:
   - adbc-driver-postgresql >=1.2.0
   - adbc-driver-sqlite >=1.2.0
@@ -3426,9 +3426,9 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/pandas?source=hash-mapping
-  size: 15143263
-  timestamp: 1771408984246
+  - pkg:pypi/pandas?source=compressed-mapping
+  size: 15154211
+  timestamp: 1774916583619
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.4-hda50119_1.conda
   sha256: 315b52bfa6d1a820f4806f6490d472581438a28e21df175290477caec18972b0
   md5: d53ffc0edc8eabf4253508008493c5bc
@@ -3463,29 +3463,29 @@ packages:
   purls: []
   size: 1222481
   timestamp: 1763655398280
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.1.1-py311hf88fc01_0.conda
-  sha256: 19b4633f001889309a9d7ad12f4a89c27bad1f268722e6e50a7d9da64773f5fc
-  md5: 0415141f4e3d4dad3c39ad4718936352
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.2.0-py311hf88fc01_0.conda
+  sha256: 5b182a7588874e497514b52e2ef278b66fa4089e94379d249897df28b917a659
+  md5: b4e4b0fc807b68aa1706457f2e31279d
   depends:
   - python
-  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - python_abi 3.11.* *_cp311
-  - libwebp-base >=1.6.0,<2.0a0
-  - tk >=8.6.13,<8.7.0a0
-  - openjpeg >=2.5.4,<3.0a0
-  - libxcb >=1.17.0,<2.0a0
-  - libtiff >=4.7.1,<4.8.0a0
-  - zlib-ng >=2.3.3,<2.4.0a0
+  - libgcc >=14
   - lcms2 >=2.18,<3.0a0
-  - libfreetype >=2.14.1
-  - libfreetype6 >=2.14.1
+  - libxcb >=1.17.0,<2.0a0
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.13,<8.7.0a0
+  - zlib-ng >=2.3.3,<2.4.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - libtiff >=4.7.1,<4.8.0a0
+  - openjpeg >=2.5.4,<3.0a0
+  - libfreetype >=2.14.3
+  - libfreetype6 >=2.14.3
   - libjpeg-turbo >=3.1.2,<4.0a0
   license: HPND
   purls:
-  - pkg:pypi/pillow?source=hash-mapping
-  size: 1046996
-  timestamp: 1770794002405
+  - pkg:pypi/pillow?source=compressed-mapping
+  size: 1056849
+  timestamp: 1775060059882
 - conda: https://conda.anaconda.org/conda-forge/noarch/pint-0.25.3-pyhc364b38_0.conda
   sha256: f58a03dd2908c15dc65fab7e03a0212c69043466f7f85a4e345470492841782f
   md5: 293c4719f6d62778ffecd18e024a8fcd
@@ -3589,9 +3589,9 @@ packages:
   - pkg:pypi/pkce?source=hash-mapping
   size: 9126
   timestamp: 1736219305828
-- conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.4-pyhcf101f3_0.conda
-  sha256: 0289f0a38337ee201d984f8f31f11f6ef076cfbbfd0ab9181d12d9d1d099bf46
-  md5: 82c1787f2a65c0155ef9652466ee98d6
+- conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
+  sha256: 8f29915c172f1f7f4f7c9391cd5dac3ebf5d13745c8b7c8006032615246345a5
+  md5: 89c0b6d1793601a2a3a3f7d2d3d8b937
   depends:
   - python >=3.10
   - python
@@ -3599,8 +3599,8 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/platformdirs?source=compressed-mapping
-  size: 25646
-  timestamp: 1773199142345
+  size: 25862
+  timestamp: 1775741140609
 - conda: https://conda.anaconda.org/neutrons/noarch/plot-publisher-1.4.0-pyhbf21a9e_0.conda
   sha256: 81a62caaffa7106937f64a656d442a5ce596455e08616cd509851813246a9f50
   md5: 7e098c2f9ddcf73f6d0a54692e6d6cbe
@@ -3820,6 +3820,7 @@ packages:
   depends:
   - python >=3.10
   license: BSD-2-Clause
+  license_family: BSD
   purls:
   - pkg:pypi/pygments?source=compressed-mapping
   size: 893031
@@ -3913,32 +3914,31 @@ packages:
   - pkg:pypi/pyqt5-sip?source=hash-mapping
   size: 85010
   timestamp: 1759495564200
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.11.0-py311hf27b23e_0.conda
-  sha256: da431d1974db6f7721b7d87ca79452c0f39bb5a73d31cee9605aec8f324f1a87
-  md5: 78202f74ac55b455e0539b6d0253964d
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.11.0-py311hf27b23e_1.conda
+  sha256: cf9ad999b82b1290e127f65e2d0db4acefc2f01c51789e935974cfce20a91337
+  md5: b3fb332c110fee191999153ccf69fad2
   depends:
   - python
   - qt6-main 6.11.0.*
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=14
   - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  - libgl >=1.7.0,<2.0a0
-  - libvulkan-loader >=1.4.341.0,<2.0a0
-  - libxslt >=1.1.43,<2.0a0
   - qt6-main >=6.11.0,<6.12.0a0
-  - libopengl >=1.7.0,<2.0a0
-  - libegl >=1.7.0,<2.0a0
+  - libvulkan-loader >=1.4.341.0,<2.0a0
   - python_abi 3.11.* *_cp311
+  - libclang13 >=21.1.8
+  - libxslt >=1.1.43,<2.0a0
+  - libgl >=1.7.0,<2.0a0
   - libxml2
   - libxml2-16 >=2.14.6
-  - libclang13 >=21.1.8
+  - libegl >=1.7.0,<2.0a0
+  - libopengl >=1.7.0,<2.0a0
   license: LGPL-3.0-only
   license_family: LGPL
   purls:
-  - pkg:pypi/pyside6?source=hash-mapping
-  - pkg:pypi/shiboken6?source=hash-mapping
-  size: 13208474
-  timestamp: 1774714569806
+  - pkg:pypi/pyside6?source=compressed-mapping
+  size: 13208608
+  timestamp: 1775055046239
 - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
   sha256: ba3b032fa52709ce0d9fd388f63d330a026754587a2f461117cac9ab73d8d0d8
   md5: 461219d1a5bd61342293efa2c0c90eac
@@ -3951,17 +3951,17 @@ packages:
   - pkg:pypi/pysocks?source=hash-mapping
   size: 21085
   timestamp: 1733217331982
-- conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
-  sha256: 9e749fb465a8bedf0184d8b8996992a38de351f7c64e967031944978de03a520
-  md5: 2b694bad8a50dc2f712f5368de866480
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
+  sha256: 960f59442173eee0731906a9077bd5ccf60f4b4226f05a22d1728ab9a21a879c
+  md5: 6a991452eadf2771952f39d43615bb3e
   depends:
+  - colorama >=0.4
   - pygments >=2.7.2
   - python >=3.10
   - iniconfig >=1.0.1
   - packaging >=22
   - pluggy >=1.5,<2
   - tomli >=1
-  - colorama >=0.4
   - exceptiongroup >=1
   - python
   constrains:
@@ -3969,9 +3969,9 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pytest?source=hash-mapping
-  size: 299581
-  timestamp: 1765062031645
+  - pkg:pypi/pytest?source=compressed-mapping
+  size: 299984
+  timestamp: 1775644472530
 - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
   sha256: 44e42919397bd00bfaa47358a6ca93d4c21493a8c18600176212ec21a8d25ca5
   md5: 67d1790eefa81ed305b89d8e314c7923
@@ -4067,9 +4067,9 @@ packages:
   - pkg:pypi/python-dateutil?source=hash-mapping
   size: 233310
   timestamp: 1751104122689
-- conda: https://conda.anaconda.org/conda-forge/noarch/python-discovery-1.2.1-pyhcf101f3_0.conda
-  sha256: 5a70a9cbcf48be522c2b82df8c7a57988eed776f159142b0d30099b61f31a35e
-  md5: f2e88fc463b249bc1f40d9ca969d9b5e
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-discovery-1.2.2-pyhcf101f3_0.conda
+  sha256: 498ad019d75ba31c7891dc6d9efc8a7ed48cd5d5973f3a9377eb1b174577d3db
+  md5: feb2e11368da12d6ce473b6573efab41
   depends:
   - python >=3.10
   - filelock >=3.15.4
@@ -4078,9 +4078,9 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/python-discovery?source=compressed-mapping
-  size: 34137
-  timestamp: 1774605818480
+  - pkg:pypi/python-discovery?source=hash-mapping
+  size: 34341
+  timestamp: 1775586706825
 - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.2.2-pyhcf101f3_0.conda
   sha256: 74e417a768f59f02a242c25e7db0aa796627b5bc8c818863b57786072aeb85e5
   md5: 130584ad9f3a513cdd71b1fdc1244e9c
@@ -4343,7 +4343,7 @@ packages:
   timestamp: 1743692373820
 - pypi: ./
   name: quicknxs
-  version: 4.17.0rc2
+  version: 4.18.0.dev20260409222629
   sha256: 87e2a0c24dc3e13035b9186304002cc3508ba40ce0046036d445dbf5455ad949
   requires_python: '>=3.10,<3.13'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/rapidjson-1.1.0.post20240409-h3f2d84a_2.conda
@@ -4359,18 +4359,18 @@ packages:
   purls: []
   size: 156074
   timestamp: 1742820732296
-- conda: https://conda.anaconda.org/conda-forge/noarch/readchar-4.2.1-pyhe01879c_0.conda
-  sha256: e8eb7be6d307f1625c6e6c100270a2eea92e6e7cc45277cd26233ce107ea9f73
-  md5: 7f24e776b0f2ffac7516e51e9d2c1e52
+- conda: https://conda.anaconda.org/conda-forge/noarch/readchar-4.2.2-pyhcf101f3_0.conda
+  sha256: ea85cacf3cc5bcd472622e58592a1966fdb196fe62facb7de9a30133dec46ff6
+  md5: b71e7f9e2ba9425275f7318f4461877f
   depends:
-  - python >=3.9
+  - python >=3.10
   - python
   license: MIT
   license_family: MIT
   purls:
   - pkg:pypi/readchar?source=hash-mapping
-  size: 15139
-  timestamp: 1750461053332
+  size: 15624
+  timestamp: 1775509908875
 - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
   sha256: 12ffde5a6f958e285aa22c191ca01bbd3d6e710aa852e00618fa6ddc59149002
   md5: d7d95fc8287ea7bf33e0e7116d2b95ec
@@ -4398,10 +4398,10 @@ packages:
   - pkg:pypi/referencing?source=hash-mapping
   size: 51788
   timestamp: 1760379115194
-- pypi: https://files.pythonhosted.org/packages/e7/26/46673bb18448c51222c6272c850484a0092f364fae8d0315be9aa1e4baa7/regex-2026.3.32-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/01/ea/4c8d306e9c36ac22417336b1e02e7b358152c34dc379673f2d331143725f/regex-2026.4.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
   name: regex
-  version: 2026.3.32
-  sha256: c5e0fdb5744caf1036dec5510f543164f2144cb64932251f6dfd42fa872b7f9c
+  version: 2026.4.4
+  sha256: 21e5eb86179b4c67b5759d452ea7c48eb135cd93308e7a260aa489ed2eb423a4
   requires_python: '>=3.10'
 - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.33.1-pyhcf101f3_0.conda
   sha256: c0249bc4bf4c0e8e06d0e7b4d117a5d593cc4ab2144d5006d6d47c83cb0af18e
@@ -4416,6 +4416,7 @@ packages:
   constrains:
   - chardet >=3.0.2,<6
   license: Apache-2.0
+  license_family: APACHE
   purls:
   - pkg:pypi/requests?source=compressed-mapping
   size: 63712
@@ -4496,10 +4497,10 @@ packages:
   - pkg:pypi/rpds-py?source=hash-mapping
   size: 383153
   timestamp: 1764543197251
-- conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.15.8-h7805a7d_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.15.10-h7805a7d_0.conda
   noarch: python
-  sha256: c4778a348a99b781585f8ef47f134a5ebfe205f9f403ecd601fc602efa7e54ce
-  md5: 67bed7148b00f10bd30766cb58fb8f6f
+  sha256: 9b1da9620cb73a58127651b71ac1bf15836aad49fbe5a4bf734a3a0e3cecf0d2
+  md5: f78d03a6c57a122772ed115c49cd743c
   depends:
   - python
   - libgcc >=14
@@ -4507,11 +4508,10 @@ packages:
   constrains:
   - __glibc >=2.17
   license: MIT
-  license_family: MIT
   purls:
   - pkg:pypi/ruff?source=compressed-mapping
-  size: 9233459
-  timestamp: 1774602134378
+  size: 9224697
+  timestamp: 1775763996127
 - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.17.1-py311hbe70eeb_0.conda
   sha256: 0063a75e9406357ef8ecc2fb38808a2442b269bfc5a854cf2bcd368060d9a2d7
   md5: 5ae6d73ab0bebbc892c2d46dc51e90a5
@@ -4636,7 +4636,7 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls:
-  - pkg:pypi/sniffio?source=hash-mapping
+  - pkg:pypi/sniffio?source=compressed-mapping
   size: 15698
   timestamp: 1762941572482
 - conda: https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-3.0.1-pyhd8ed1ab_0.conda
@@ -4961,9 +4961,9 @@ packages:
   - pkg:pypi/traitlets?source=hash-mapping
   size: 110051
   timestamp: 1733367480074
-- conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.24.0-pyhcf101f3_0.conda
-  sha256: e1116d08e6a55b2b42a090130c268f75211ad8e6a8e7749e977924de3864d487
-  md5: 10870929f587540c5802cd9b071cba5c
+- conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.24.1-pyhcf101f3_0.conda
+  sha256: 859aec3457a4d6dd6e4a68d9f4ad4216ce05e1a1a94d244f10629848de77739b
+  md5: 0bb9dfbe0806165f4960331a0ac05ab5
   depends:
   - annotated-doc >=0.0.2
   - click >=8.2.1
@@ -4974,9 +4974,9 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/typer?source=hash-mapping
-  size: 117860
-  timestamp: 1771292312899
+  - pkg:pypi/typer?source=compressed-mapping
+  size: 116134
+  timestamp: 1775138098187
 - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
   sha256: 7c2df5721c742c2a47b2c8f960e718c930031663ac1174da67c1ed5999f7938c
   md5: edd329d7d3a4ab45dcf905899a7a6115
@@ -5090,9 +5090,9 @@ packages:
   - pkg:pypi/versioningit?source=hash-mapping
   size: 167034
   timestamp: 1751113901223
-- conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-21.2.0-pyhcf101f3_0.conda
-  sha256: b83246d145ba0e6814d2ed0b616293e56924e6c7d6649101f5a4f97f9e757ed1
-  md5: 704c22301912f7e37d0a92b2e7d5942d
+- conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-21.2.1-pyhcf101f3_0.conda
+  sha256: a3b38bb79ebbb830574b6e0ba1303f103601b5ed658ac400a3f9e43806e8e4fe
+  md5: fa76df129efc4550f272d8668acbe658
   depends:
   - python >=3.10
   - distlib >=0.3.7,<1
@@ -5103,11 +5103,10 @@ packages:
   - typing_extensions >=4.13.2
   - python
   license: MIT
-  license_family: MIT
   purls:
   - pkg:pypi/virtualenv?source=compressed-mapping
-  size: 4647775
-  timestamp: 1773133660203
+  size: 4658762
+  timestamp: 1775771531130
 - conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.25.0-hd6090a7_0.conda
   sha256: ea374d57a8fcda281a0a89af0ee49a2c2e99cc4ac97cf2e2db7064e74e764bdb
   md5: 996583ea9c796e5b915f7d7580b51ea6
@@ -5130,7 +5129,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/wcwidth?source=compressed-mapping
+  - pkg:pypi/wcwidth?source=hash-mapping
   size: 71550
   timestamp: 1770634638503
 - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
@@ -5144,9 +5143,9 @@ packages:
   - pkg:pypi/webencodings?source=hash-mapping
   size: 15496
   timestamp: 1733236131358
-- conda: https://conda.anaconda.org/conda-forge/noarch/werkzeug-3.1.7-pyhcf101f3_0.conda
-  sha256: 09241e315a7c82eda22873770c0c919a01a1b1e5f14665fb191ab1d18be66eff
-  md5: 38cf6cde8cb2068fc896c7248e60f8ab
+- conda: https://conda.anaconda.org/conda-forge/noarch/werkzeug-3.1.8-pyhcf101f3_0.conda
+  sha256: 5108c1bf2f0512e5c9dc8191e31b144c23b7cf0e73423a246173006002368d79
+  md5: 3eeca039e7316268627f4116da9df64c
   depends:
   - markupsafe >=2.1.1
   - python >=3.10
@@ -5155,8 +5154,8 @@ packages:
   license_family: BSD
   purls:
   - pkg:pypi/werkzeug?source=compressed-mapping
-  size: 258058
-  timestamp: 1774357640759
+  size: 258232
+  timestamp: 1775160081069
 - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.46.3-pyhd8ed1ab_0.conda
   sha256: d6cf2f0ebd5e09120c28ecba450556ce553752652d91795442f0e70f837126ae
   md5: bdbd7385b4a67025ac2dba4ef8cb6a8f

--- a/src/quicknxs/ui/mplwidget.py
+++ b/src/quicknxs/ui/mplwidget.py
@@ -98,7 +98,11 @@ def _extract_errorbar_data(ax):
         bar_collections = container[2]
         if bar_collections:
             segments = bar_collections[0].get_segments()
-            error = np.array([(seg[1, 1] - seg[0, 1]) / 2.0 for seg in segments])
+            # Matplotlib stores empty (0,) segments for NaN/masked data points;
+            # return NaN as the error for those points.
+            error = np.array(
+                [(seg[1, 1] - seg[0, 1]) / 2.0 if seg.ndim >= 2 and seg.shape[0] >= 2 else np.nan for seg in segments]
+            )
         else:
             error = np.zeros_like(y)
         label = container.get_label() or f"dataset_{len(datasets)}"
@@ -627,17 +631,21 @@ class NavigationToolbarReflectivity(NavigationToolbar):
             else:
                 line.set_ydata(y / x**4)
 
-        # scale the error bar data
+        # scale the error bar data (skip empty segments from NaN/masked points)
         for c in ax.collections:
             segments = c.get_segments()
             scaled_segments = []
             for segment in segments:
-                if is_yaxis_q_pow_4:
-                    segment[0][1] = segment[0][1] * segment[0][0] ** 4
-                    segment[1][1] = segment[1][1] * segment[1][0] ** 4
-                else:
-                    segment[0][1] = segment[0][1] / segment[0][0] ** 4
-                    segment[1][1] = segment[1][1] / segment[1][0] ** 4
+                if segment.ndim >= 2 and segment.shape[0] >= 2:
+                    if is_yaxis_q_pow_4:
+                        segment[0][1] = segment[0][1] * segment[0][0] ** 4
+                        segment[1][1] = segment[1][1] * segment[1][0] ** 4
+                    else:
+                        segment[0][1] = segment[0][1] / segment[0][0] ** 4
+                        segment[1][1] = segment[1][1] / segment[1][0] ** 4
+                elif segment.ndim < 2:
+                    # Reshape 1D empty segments to (0, 2) so set_segments/Path accepts them
+                    segment = np.empty((0, 2))
                 scaled_segments.append(segment)
             c.set_segments(scaled_segments)
 

--- a/src/quicknxs/ui/mplwidget.py
+++ b/src/quicknxs/ui/mplwidget.py
@@ -101,7 +101,8 @@ def _extract_errorbar_data(ax):
             # Matplotlib stores empty (0,) segments for NaN/masked data points;
             # return NaN as the error for those points.
             error = np.array(
-                [(seg[1, 1] - seg[0, 1]) / 2.0 if seg.ndim >= 2 and seg.shape[0] >= 2 else np.nan for seg in segments]
+                [abs(seg[1, 1] - seg[0, 1]) / 2.0 if seg.ndim == 2 and seg.shape == (2, 2) else np.nan
+                 for seg in segments]
             )
         else:
             error = np.zeros_like(y)

--- a/src/quicknxs/ui/mplwidget.py
+++ b/src/quicknxs/ui/mplwidget.py
@@ -102,8 +102,10 @@ def _extract_errorbar_data(ax):
             # Matplotlib stores empty (0,) segments for NaN/masked data points;
             # return NaN as the error for those points.
             error = np.array(
-                [abs(seg[1, 1] - seg[0, 1]) / 2.0 if seg.ndim == 2 and seg.shape == (2, 2) else np.nan
-                 for seg in segments]
+                [
+                    abs(seg[1, 1] - seg[0, 1]) / 2.0 if seg.ndim == 2 and seg.shape == (2, 2) else np.nan
+                    for seg in segments
+                ]
             )
         else:
             error = np.zeros_like(y)

--- a/src/quicknxs/ui/mplwidget.py
+++ b/src/quicknxs/ui/mplwidget.py
@@ -16,6 +16,7 @@ import matplotlib.colors
 import numpy as np
 from matplotlib.backends.backend_qt import NavigationToolbar2QT
 from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
+from matplotlib.collections import QuadMesh
 from matplotlib.colors import LogNorm, Normalize
 from matplotlib.figure import Figure
 from qtpy import QtCore, QtGui, QtPrintSupport, QtWidgets
@@ -76,7 +77,7 @@ def _detect_plot_type(ax):
     """
     if len(ax.images) > 0:
         return "imshow"
-    if any(c.__class__.__name__ == "QuadMesh" for c in ax.collections):
+    if any(isinstance(c, QuadMesh) for c in ax.collections):
         return "pcolormesh"
     if len(_errorbar_containers(ax)) > 0:
         return "errorbar"
@@ -147,7 +148,7 @@ def _extract_pcolormesh_data(ax):
     GISANS data use irregular grids where each cell has unique (x, y).
     Multiple surfaces (one per run file) are captured as a list.
     """
-    quadmeshes = [c for c in ax.collections if c.__class__.__name__ == "QuadMesh"]
+    quadmeshes = [c for c in ax.collections if isinstance(c, QuadMesh)]
     qm0 = quadmeshes[0]
     norm = qm0.norm
 
@@ -501,17 +502,18 @@ class NavigationToolbar(NavigationToolbar2QT):
             }
             extracted = extractor[plot_type](ax)
 
-            filters = "ASCII data (*.dat);;Numpy archive (*.npz);;Pickle (*.pkl)"
+            filters = "ASCII data (*.dat);;Numpy archive (*.npz);;Pickle [trusted sources only] (*.pkl)"
             fname, selected_filter = QtWidgets.QFileDialog.getSaveFileName(self, "Save plot data", "", filters)
             if not fname:
                 return
 
-            _, ext = os.path.splitext(fname)
+            base, ext = os.path.splitext(fname)
             ext = ext.lower()
             if ext not in (".dat", ".npz", ".pkl"):
                 for candidate in (".dat", ".npz", ".pkl"):
                     if f"*{candidate}" in selected_filter:
-                        fname += candidate
+                        # Replace unrecognized extension; append only when none was given
+                        fname = (base if ext else fname) + candidate
                         ext = candidate
                         break
                 else:
@@ -527,7 +529,7 @@ class NavigationToolbar(NavigationToolbar2QT):
             logging.info(f"Saved {plot_type} data to {fname}")
 
         except Exception as e:
-            logging.error(f"Error saving data: {e}")
+            logging.exception("Error saving data")
             QtWidgets.QMessageBox.critical(
                 self,
                 "Error saving data",
@@ -549,7 +551,7 @@ class NavigationToolbarGeneric(NavigationToolbar):
 
     def toggle_log(self, *args):
         ax = self.canvas.ax
-        if len(ax.images) == 0 and all([c.__class__.__name__ != "QuadMesh" for c in ax.collections]):
+        if len(ax.images) == 0 and all(not isinstance(c, QuadMesh) for c in ax.collections):
             logstate = ax.get_yscale()
             if logstate == "linear":
                 ax.set_yscale("log")
@@ -557,7 +559,7 @@ class NavigationToolbarGeneric(NavigationToolbar):
                 ax.set_yscale("linear")
             self.canvas.draw()
         else:
-            imgs = ax.images + [c for c in ax.collections if c.__class__.__name__ == "QuadMesh"]
+            imgs = ax.images + [c for c in ax.collections if isinstance(c, QuadMesh)]
             norm = imgs[0].norm
             if norm.__class__ is LogNorm:
                 for img in imgs:

--- a/src/quicknxs/ui/mplwidget.py
+++ b/src/quicknxs/ui/mplwidget.py
@@ -7,7 +7,9 @@ Plotting widget taken from QuickNXS.
 """
 
 import inspect
+import logging
 import os
+import pickle
 import tempfile
 
 import matplotlib.colors
@@ -49,6 +51,336 @@ def getIcon(filename: str) -> "QtGui.QIcon":
     return icon
 
 
+def centerbins(xvals):
+    """For a given numpy array of bin edges, return the bin centers."""
+    new_xvals = (xvals + np.roll(xvals, -1)) / 2
+    return np.delete(new_xvals, -1)
+
+
+def _data_lines(ax):
+    """Return lines that carry plotted data, excluding overlay markers (axvline/axhline)."""
+    return [line for line in ax.lines if line.get_transform() == ax.transData]
+
+
+def _errorbar_containers(ax):
+    """Return ErrorbarContainer objects from the axes, if any."""
+    from matplotlib.container import ErrorbarContainer
+
+    return [c for c in ax.containers if isinstance(c, ErrorbarContainer)]
+
+
+def _detect_plot_type(ax):
+    """Classify the current axes content.
+
+    Returns one of: ``"imshow"``, ``"pcolormesh"``, ``"errorbar"``, ``"line"``, ``"empty"``.
+    """
+    if len(ax.images) > 0:
+        return "imshow"
+    if any(c.__class__.__name__ == "QuadMesh" for c in ax.collections):
+        return "pcolormesh"
+    if len(_errorbar_containers(ax)) > 0:
+        return "errorbar"
+    lines = _data_lines(ax)
+    if len(lines) == 0:
+        return "empty"
+    return "line"
+
+
+def _extract_errorbar_data(ax):
+    """Extract X, Y, Error datasets from ErrorbarContainer objects."""
+    containers = _errorbar_containers(ax)
+    datasets = []
+    for container in containers:
+        data_line = container[0]
+        x = np.array(data_line.get_xdata(), dtype=float)
+        y = np.array(data_line.get_ydata(), dtype=float)
+        # Extract error from the vertical bar LineCollection segments
+        bar_collections = container[2]
+        if bar_collections:
+            segments = bar_collections[0].get_segments()
+            error = np.array([(seg[1, 1] - seg[0, 1]) / 2.0 for seg in segments])
+        else:
+            error = np.zeros_like(y)
+        label = container.get_label() or f"dataset_{len(datasets)}"
+        datasets.append({"x": x, "y": y, "error": error, "label": label})
+    return {
+        "datasets": datasets,
+        "xlabel": ax.get_xlabel(),
+        "ylabel": ax.get_ylabel(),
+        "title": ax.get_title(),
+        "xscale": ax.get_xscale(),
+        "yscale": ax.get_yscale(),
+    }
+
+
+def _extract_imshow_data(ax):
+    """Extract the 2D array, extent, origin, norm, and colormap from an imshow plot."""
+    img = ax.images[0]
+    data = np.array(img.get_array(), dtype=float)
+    extent = np.array(img.get_extent())
+    norm = img.norm
+    return {
+        "data": data,
+        "extent": extent,
+        "origin": img.origin,
+        "cmap": img.get_cmap().name,
+        "norm": type(norm).__name__,
+        "norm_vmin": float(norm.vmin) if norm.vmin is not None else None,
+        "norm_vmax": float(norm.vmax) if norm.vmax is not None else None,
+        "xlabel": ax.get_xlabel(),
+        "ylabel": ax.get_ylabel(),
+        "title": ax.get_title(),
+    }
+
+
+def _extract_pcolormesh_data(ax):
+    """Extract mesh coordinates and Z values from all QuadMesh objects on the axes.
+
+    Handles both flat shading (1D edge arrays, z is one smaller per dim) and
+    gouraud shading (2D node grids, z matches coordinate dims).  For gouraud
+    meshes the full 2D coordinate grids are preserved because off-specular and
+    GISANS data use irregular grids where each cell has unique (x, y).
+    Multiple surfaces (one per run file) are captured as a list.
+    """
+    quadmeshes = [c for c in ax.collections if c.__class__.__name__ == "QuadMesh"]
+    qm0 = quadmeshes[0]
+    norm = qm0.norm
+
+    surfaces = []
+    for qm in quadmeshes:
+        coords = qm.get_coordinates()
+        z_data = np.array(qm.get_array(), dtype=float)
+        is_gouraud = z_data.shape == (coords.shape[0], coords.shape[1])
+
+        if is_gouraud:
+            surfaces.append(
+                {
+                    "x_grid": np.array(coords[:, :, 0], dtype=float),
+                    "y_grid": np.array(coords[:, :, 1], dtype=float),
+                    "z_data": z_data,
+                }
+            )
+        else:
+            x_coords_1d = coords[0, :, 0]
+            y_coords_1d = coords[:, 0, 1]
+            ny, nx = coords.shape[0] - 1, coords.shape[1] - 1
+            if z_data.ndim == 1:
+                z_data = z_data.reshape(ny, nx)
+            surfaces.append(
+                {
+                    "x_edges": x_coords_1d,
+                    "y_edges": y_coords_1d,
+                    "x_centers": centerbins(x_coords_1d),
+                    "y_centers": centerbins(y_coords_1d),
+                    "z_data": z_data,
+                }
+            )
+
+    # Use first surface to determine shading type
+    first_coords = quadmeshes[0].get_coordinates()
+    first_z = np.array(quadmeshes[0].get_array(), dtype=float)
+    shading = "gouraud" if first_z.shape == (first_coords.shape[0], first_coords.shape[1]) else "flat"
+
+    return {
+        "surfaces": surfaces,
+        "shading": shading,
+        "xlabel": ax.get_xlabel(),
+        "ylabel": ax.get_ylabel(),
+        "title": ax.get_title(),
+        "cmap": qm0.get_cmap().name,
+        "norm": type(norm).__name__,
+        "norm_vmin": float(norm.vmin) if norm.vmin is not None else None,
+        "norm_vmax": float(norm.vmax) if norm.vmax is not None else None,
+    }
+
+
+def _extract_line_data(ax):
+    """Extract X, Y data from simple line plots (non-errorbar)."""
+    lines = _data_lines(ax)
+    datasets = []
+    for line in lines:
+        x = np.array(line.get_xdata(), dtype=float)
+        y = np.array(line.get_ydata(), dtype=float)
+        label = line.get_label() or f"dataset_{len(datasets)}"
+        datasets.append({"x": x, "y": y, "label": label})
+    return {
+        "datasets": datasets,
+        "xlabel": ax.get_xlabel(),
+        "ylabel": ax.get_ylabel(),
+        "title": ax.get_title(),
+        "xscale": ax.get_xscale(),
+        "yscale": ax.get_yscale(),
+    }
+
+
+def _save_dat(fname, extracted, plot_type):
+    """Save extracted data as ASCII table."""
+    if plot_type == "errorbar":
+        _save_dat_errorbar(fname, extracted)
+    elif plot_type == "line":
+        _save_dat_line(fname, extracted)
+    elif plot_type == "imshow":
+        _save_dat_imshow(fname, extracted)
+    elif plot_type == "pcolormesh":
+        _save_dat_pcolormesh(fname, extracted)
+    else:
+        raise ValueError(f"Cannot save plot type '{plot_type}' as .dat")
+
+
+def _save_dat_errorbar(fname, extracted):
+    with open(fname, "w") as f:
+        f.write(f"# title: {extracted['title']}\n")
+        f.write(f"# xlabel: {extracted['xlabel']}\n")
+        f.write(f"# ylabel: {extracted['ylabel']}\n")
+        f.write(f"# xscale: {extracted.get('xscale', 'linear')}\n")
+        f.write(f"# yscale: {extracted.get('yscale', 'linear')}\n")
+        for i, ds in enumerate(extracted["datasets"]):
+            f.write(f"# Dataset {i}: {ds['label']}\n")
+            f.write(f"# {extracted['xlabel']}\t{extracted['ylabel']}\tError\n")
+            block = np.column_stack([ds["x"], ds["y"], ds["error"]])
+            np.savetxt(f, block, delimiter="\t")
+            if i < len(extracted["datasets"]) - 1:
+                f.write("\n\n")
+
+
+def _save_dat_line(fname, extracted):
+    with open(fname, "w") as f:
+        f.write(f"# title: {extracted['title']}\n")
+        f.write(f"# xlabel: {extracted['xlabel']}\n")
+        f.write(f"# ylabel: {extracted['ylabel']}\n")
+        f.write(f"# xscale: {extracted.get('xscale', 'linear')}\n")
+        f.write(f"# yscale: {extracted.get('yscale', 'linear')}\n")
+        for i, ds in enumerate(extracted["datasets"]):
+            f.write(f"# Dataset {i}: {ds['label']}\n")
+            f.write(f"# {extracted['xlabel']}\t{extracted['ylabel']}\n")
+            block = np.column_stack([ds["x"], ds["y"]])
+            np.savetxt(f, block, delimiter="\t")
+            if i < len(extracted["datasets"]) - 1:
+                f.write("\n\n")
+
+
+def _save_dat_imshow(fname, extracted):
+    header_lines = [
+        f"title: {extracted['title']}",
+        f"xlabel: {extracted['xlabel']}",
+        f"ylabel: {extracted['ylabel']}",
+        f"extent: xmin={extracted['extent'][0]}, xmax={extracted['extent'][1]}, "
+        f"ymin={extracted['extent'][2]}, ymax={extracted['extent'][3]}",
+        f"origin: {extracted['origin']}",
+        f"cmap: {extracted.get('cmap', 'default')}",
+        f"norm: {extracted.get('norm', 'Normalize')}",
+        f"norm_vmin: {extracted.get('norm_vmin', '')}",
+        f"norm_vmax: {extracted.get('norm_vmax', '')}",
+    ]
+    np.savetxt(fname, extracted["data"], header="\n".join(header_lines), delimiter="\t")
+
+
+def _save_dat_pcolormesh(fname, extracted):
+    """Save pcolormesh data in gnuplot splot xyz format.
+
+    Each row is ``x y z``.  Blank lines separate grid rows within a surface.
+    Two blank lines separate successive surfaces.  Multiple surfaces arise
+    when several run files are overlaid on the same axes.
+    """
+    surfaces = extracted["surfaces"]
+    shading = extracted.get("shading", "flat")
+    ny, nx = surfaces[0]["z_data"].shape
+
+    with open(fname, "w") as f:
+        f.write(f"# title: {extracted['title']}\n")
+        f.write(f"# xlabel: {extracted['xlabel']}\n")
+        f.write(f"# ylabel: {extracted['ylabel']}\n")
+        f.write(f"# shading: {shading}\n")
+        f.write(f"# n_surfaces: {len(surfaces)}\n")
+        f.write(f"# grid: {ny} {nx}\n")
+        f.write(f"# cmap: {extracted.get('cmap', 'default')}\n")
+        f.write(f"# norm: {extracted.get('norm', 'Normalize')}\n")
+        f.write(f"# norm_vmin: {extracted.get('norm_vmin', '')}\n")
+        f.write(f"# norm_vmax: {extracted.get('norm_vmax', '')}\n")
+        f.write(f"# {extracted['xlabel']}\t{extracted['ylabel']}\tZ\n")
+
+        for si, surf in enumerate(surfaces):
+            z_data = surf["z_data"]
+            s_ny, s_nx = z_data.shape
+            if shading == "gouraud":
+                x_grid = surf["x_grid"]
+                y_grid = surf["y_grid"]
+                for iy in range(s_ny):
+                    for ix in range(s_nx):
+                        f.write(f"{x_grid[iy, ix]:.6g}\t{y_grid[iy, ix]:.6g}\t{z_data[iy, ix]:.6g}\n")
+                    if iy < s_ny - 1:
+                        f.write("\n")
+            else:
+                x_vals = surf["x_centers"]
+                y_vals = surf["y_centers"]
+                for ix, xc in enumerate(x_vals):
+                    for iy, yc in enumerate(y_vals):
+                        f.write(f"{xc:.6g}\t{yc:.6g}\t{z_data[iy, ix]:.6g}\n")
+                    if ix < len(x_vals) - 1:
+                        f.write("\n")
+            if si < len(surfaces) - 1:
+                f.write("\n\n")
+
+
+def _save_npz(fname, extracted, plot_type):
+    """Save extracted data as a compressed numpy archive."""
+    save_dict = {"plot_type": np.array(plot_type)}
+    if plot_type in ("errorbar", "line"):
+        save_dict["n_datasets"] = np.array(len(extracted["datasets"]))
+        for i, ds in enumerate(extracted["datasets"]):
+            save_dict[f"x_{i}"] = ds["x"]
+            save_dict[f"y_{i}"] = ds["y"]
+            if "error" in ds:
+                save_dict[f"error_{i}"] = ds["error"]
+            save_dict[f"label_{i}"] = np.array(ds["label"])
+        save_dict["xscale"] = np.array(extracted.get("xscale", "linear"))
+        save_dict["yscale"] = np.array(extracted.get("yscale", "linear"))
+    elif plot_type == "imshow":
+        save_dict["data"] = extracted["data"]
+        save_dict["extent"] = extracted["extent"]
+        save_dict["origin"] = np.array(extracted["origin"])
+        save_dict["cmap"] = np.array(extracted.get("cmap", "default"))
+        save_dict["norm"] = np.array(extracted.get("norm", "Normalize"))
+        if extracted.get("norm_vmin") is not None:
+            save_dict["norm_vmin"] = np.array(extracted["norm_vmin"])
+        if extracted.get("norm_vmax") is not None:
+            save_dict["norm_vmax"] = np.array(extracted["norm_vmax"])
+    elif plot_type == "pcolormesh":
+        shading = extracted.get("shading", "flat")
+        surfaces = extracted["surfaces"]
+        save_dict["shading"] = np.array(shading)
+        save_dict["n_surfaces"] = np.array(len(surfaces))
+        save_dict["cmap"] = np.array(extracted.get("cmap", "default"))
+        save_dict["norm"] = np.array(extracted.get("norm", "Normalize"))
+        if extracted.get("norm_vmin") is not None:
+            save_dict["norm_vmin"] = np.array(extracted["norm_vmin"])
+        if extracted.get("norm_vmax") is not None:
+            save_dict["norm_vmax"] = np.array(extracted["norm_vmax"])
+        for i, surf in enumerate(surfaces):
+            save_dict[f"z_data_{i}"] = surf["z_data"]
+            if shading == "gouraud":
+                save_dict[f"x_grid_{i}"] = surf["x_grid"]
+                save_dict[f"y_grid_{i}"] = surf["y_grid"]
+            else:
+                save_dict[f"x_edges_{i}"] = surf["x_edges"]
+                save_dict[f"y_edges_{i}"] = surf["y_edges"]
+    save_dict["xlabel"] = np.array(extracted.get("xlabel", ""))
+    save_dict["ylabel"] = np.array(extracted.get("ylabel", ""))
+    save_dict["title"] = np.array(extracted.get("title", ""))
+    np.savez_compressed(fname, **save_dict)
+
+
+def _save_pkl(fname, figure, extracted, plot_type):
+    """Save figure and extracted data as a pickle file."""
+    payload = {
+        "figure": figure,
+        "plot_type": plot_type,
+        "data": extracted,
+    }
+    with open(fname, "wb") as f:
+        pickle.dump(payload, f, protocol=4)
+
+
 class NavigationToolbar(NavigationToolbar2QT):
     """A small change to the original navigation toolbar."""
 
@@ -73,7 +405,7 @@ class NavigationToolbar(NavigationToolbar2QT):
         icon = getIcon("saveData.png")
         self.addSeparator()
         a = self.addAction(icon, "SaveData", self.save_data)
-        a.setToolTip("Save XYE data to file")
+        a.setToolTip("Save plot data to file")
 
         # Add the x,y location widget at the right side of the toolbar
         # The stretch factor is 1 which means any resizing of the toolbar
@@ -149,32 +481,55 @@ class NavigationToolbar(NavigationToolbar2QT):
                 )
 
     def save_data(self):
+        """Save the current plot data to file (.dat, .npz, or .pkl)."""
         ax = self.canvas.ax
+        try:
+            plot_type = _detect_plot_type(ax)
+            if plot_type == "empty":
+                raise ValueError("No data to save: the plot is empty.")
 
-        if hasattr(ax, "get_array") == False:
-            if np.mod(len(ax.lines), 3) == 1:
-                data_to_save = ax.lines[0].get_xydata()
-            if np.mod(len(ax.lines), 3) == 0:
-                data_to_save = np.empty((0, 3), float)
-                for i in range(0, int(len(ax.lines)), 3):
-                    xdata_from_plot = ax.lines[i].get_xdata()
-                    ydata_from_plot = ax.lines[i].get_ydata()
-                    err_from_plot = (ax.lines[i + 2].get_ydata() - ax.lines[i + 1].get_ydata()) / 2.0
-                    data_to_save = np.append(
-                        data_to_save, np.array([xdata_from_plot, ydata_from_plot, err_from_plot]).transpose(), axis=0
-                    )
-        else:
-            data_to_save = ax.get_array()
+            extractor = {
+                "errorbar": _extract_errorbar_data,
+                "imshow": _extract_imshow_data,
+                "pcolormesh": _extract_pcolormesh_data,
+                "line": _extract_line_data,
+            }
+            extracted = extractor[plot_type](ax)
 
-        fname = QtWidgets.QFileDialog.getSaveFileName(self, "Choose a filename to save to")
+            filters = "ASCII data (*.dat);;Numpy archive (*.npz);;Pickle (*.pkl)"
+            fname, selected_filter = QtWidgets.QFileDialog.getSaveFileName(self, "Save plot data", "", filters)
+            if not fname:
+                return
 
-        if type(fname[0]) == str:
-            try:
-                np.savetxt(fname[0], data_to_save)
-            except Exception as e:
-                QtWidgets.QMessageBox.critical(
-                    self, "Error saving file", str(e), QtWidgets.QMessageBox.Ok, QtWidgets.QMessageBox.NoButton
-                )
+            _, ext = os.path.splitext(fname)
+            ext = ext.lower()
+            if ext not in (".dat", ".npz", ".pkl"):
+                for candidate in (".dat", ".npz", ".pkl"):
+                    if f"*{candidate}" in selected_filter:
+                        fname += candidate
+                        ext = candidate
+                        break
+                else:
+                    raise ValueError(f"Unknown file format: {ext or '(none)'}")
+
+            if ext == ".dat":
+                _save_dat(fname, extracted, plot_type)
+            elif ext == ".npz":
+                _save_npz(fname, extracted, plot_type)
+            elif ext == ".pkl":
+                _save_pkl(fname, self.canvas.figure, extracted, plot_type)
+
+            logging.info(f"Saved {plot_type} data to {fname}")
+
+        except Exception as e:
+            logging.error(f"Error saving data: {e}")
+            QtWidgets.QMessageBox.critical(
+                self,
+                "Error saving data",
+                str(e),
+                QtWidgets.QMessageBox.Ok,
+                QtWidgets.QMessageBox.NoButton,
+            )
 
 
 class NavigationToolbarGeneric(NavigationToolbar):

--- a/test/ui/test_mplwidget.py
+++ b/test/ui/test_mplwidget.py
@@ -1,3 +1,5 @@
+import pickle
+
 import numpy as np
 from matplotlib.collections import LineCollection
 from matplotlib.lines import Line2D
@@ -5,7 +7,13 @@ from numpy.testing import assert_allclose
 from PyQt5 import QtWidgets
 
 from quicknxs.interfaces.main_window import MainWindow
-from quicknxs.ui.mplwidget import NavigationToolbar, NavigationToolbarGeneric, NavigationToolbarReflectivity
+from quicknxs.ui.mplwidget import (
+    MPLWidget,
+    NavigationToolbar,
+    NavigationToolbarGeneric,
+    NavigationToolbarReflectivity,
+    _detect_plot_type,
+)
 
 
 def _refl_data():
@@ -128,3 +136,494 @@ class TestNavigationToolbar:
         # check that the plot data has been scaled by Q^4
         _compare_lines_data(lines, gold_data, is_q4_plot=True)
         _compare_error_bar_data(collections, gold_data, is_q4_plot=True)
+
+
+class TestSaveData:
+    """Test save_data() across all plot types and output formats."""
+
+    # -- helpers --
+
+    @staticmethod
+    def _make_widget(qtbot):
+        w = MPLWidget()
+        qtbot.addWidget(w)
+        return w
+
+    @staticmethod
+    def _mock_dialog(monkeypatch, path, filter_str="ASCII data (*.dat)"):
+        monkeypatch.setattr(
+            QtWidgets.QFileDialog,
+            "getSaveFileName",
+            staticmethod(lambda *_a, **_kw: (path, filter_str)),
+        )
+
+    # -- plot type detection --
+
+    def test_detect_empty(self, qtbot):
+        w = self._make_widget(qtbot)
+        assert _detect_plot_type(w.canvas.ax) == "empty"
+
+    def test_detect_errorbar(self, qtbot):
+        w = self._make_widget(qtbot)
+        w.errorbar([1, 2], [3, 4], yerr=[0.1, 0.2])
+        assert _detect_plot_type(w.canvas.ax) == "errorbar"
+
+    def test_detect_imshow(self, qtbot):
+        w = self._make_widget(qtbot)
+        w.imshow(np.ones((5, 5)), extent=[0, 1, 0, 1])
+        assert _detect_plot_type(w.canvas.ax) == "imshow"
+
+    def test_detect_pcolormesh(self, qtbot):
+        w = self._make_widget(qtbot)
+        x = np.arange(4)
+        y = np.arange(3)
+        z = np.ones((2, 3))
+        w.pcolormesh(x, y, z)
+        assert _detect_plot_type(w.canvas.ax) == "pcolormesh"
+
+    def test_detect_line(self, qtbot):
+        w = self._make_widget(qtbot)
+        w.plot([1, 2, 3], [4, 5, 6])
+        assert _detect_plot_type(w.canvas.ax) == "line"
+
+    def test_detect_imshow_with_overlays(self, qtbot):
+        w = self._make_widget(qtbot)
+        w.imshow(np.ones((5, 5)), extent=[0, 1, 0, 1])
+        w.canvas.ax.axvline(0.5, color="red")
+        w.canvas.ax.axhline(0.5, color="green")
+        assert _detect_plot_type(w.canvas.ax) == "imshow"
+
+    # -- errorbar saves --
+
+    def test_save_errorbar_dat(self, qtbot, tmp_path, monkeypatch):
+        w = self._make_widget(qtbot)
+        x = np.array([1.0, 2.0, 3.0])
+        y = np.array([10.0, 20.0, 30.0])
+        e = np.array([0.5, 1.0, 1.5])
+        w.errorbar(x, y, yerr=e)
+        out = str(tmp_path / "test.dat")
+        self._mock_dialog(monkeypatch, out)
+        w.toolbar.save_data()
+        loaded = np.loadtxt(out)
+        assert_allclose(loaded[:, 0], x)
+        assert_allclose(loaded[:, 1], y)
+        assert_allclose(loaded[:, 2], e)
+
+    def test_save_errorbar_npz(self, qtbot, tmp_path, monkeypatch):
+        w = self._make_widget(qtbot)
+        x = np.array([1.0, 2.0])
+        y = np.array([10.0, 20.0])
+        e = np.array([0.5, 1.0])
+        w.errorbar(x, y, yerr=e)
+        out = str(tmp_path / "test.npz")
+        self._mock_dialog(monkeypatch, out, "Numpy archive (*.npz)")
+        w.toolbar.save_data()
+        data = np.load(out, allow_pickle=True)
+        assert str(data["plot_type"]) == "errorbar"
+        assert_allclose(data["x_0"], x)
+        assert_allclose(data["y_0"], y)
+        assert_allclose(data["error_0"], e)
+
+    def test_save_errorbar_pkl(self, qtbot, tmp_path, monkeypatch):
+        w = self._make_widget(qtbot)
+        w.errorbar([1, 2], [3, 4], yerr=[0.1, 0.2])
+        out = str(tmp_path / "test.pkl")
+        self._mock_dialog(monkeypatch, out, "Pickle (*.pkl)")
+        w.toolbar.save_data()
+        with open(out, "rb") as f:
+            payload = pickle.load(f)
+        assert payload["plot_type"] == "errorbar"
+        assert "figure" in payload
+        assert len(payload["data"]["datasets"]) == 1
+
+    # -- imshow saves --
+
+    def test_save_imshow_dat(self, qtbot, tmp_path, monkeypatch):
+        w = self._make_widget(qtbot)
+        arr = np.array([[1.0, 2.0], [3.0, 4.0]])
+        w.imshow(arr, extent=[0, 1, 0, 1], update=False)
+        out = str(tmp_path / "test.dat")
+        self._mock_dialog(monkeypatch, out)
+        w.toolbar.save_data()
+        loaded = np.loadtxt(out)
+        assert_allclose(loaded, arr)
+
+    def test_save_imshow_npz(self, qtbot, tmp_path, monkeypatch):
+        w = self._make_widget(qtbot)
+        arr = np.array([[1.0, 2.0], [3.0, 4.0]])
+        w.imshow(arr, extent=[0, 10, 0, 20], update=False)
+        out = str(tmp_path / "test.npz")
+        self._mock_dialog(monkeypatch, out, "Numpy archive (*.npz)")
+        w.toolbar.save_data()
+        data = np.load(out)
+        assert str(data["plot_type"]) == "imshow"
+        assert_allclose(data["extent"], [0, 10, 0, 20])
+
+    # -- pcolormesh saves (flat shading, 1D edge arrays) --
+
+    def test_save_pcolormesh_flat_dat(self, qtbot, tmp_path, monkeypatch):
+        w = self._make_widget(qtbot)
+        x_edges = np.array([0.0, 1.0, 2.0, 3.0])
+        y_edges = np.array([0.0, 1.0, 2.0])
+        z = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+        w.pcolormesh(x_edges, y_edges, z)
+        out = str(tmp_path / "test.dat")
+        self._mock_dialog(monkeypatch, out)
+        w.toolbar.save_data()
+        text = open(out).read()
+        assert "shading: flat" in text
+        rows = np.loadtxt(out)
+        assert rows.shape == (6, 3)
+        # x_centers=[0.5,1.5,2.5], y_centers=[0.5,1.5]
+        assert_allclose(rows[0], [0.5, 0.5, 1.0])
+        assert_allclose(rows[1], [0.5, 1.5, 4.0])
+        assert_allclose(rows[4], [2.5, 0.5, 3.0])
+        assert_allclose(rows[5], [2.5, 1.5, 6.0])
+
+    def test_save_pcolormesh_flat_npz(self, qtbot, tmp_path, monkeypatch):
+        w = self._make_widget(qtbot)
+        x_edges = np.array([0.0, 1.0, 2.0, 3.0])
+        y_edges = np.array([0.0, 1.0, 2.0])
+        z = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+        w.pcolormesh(x_edges, y_edges, z)
+        out = str(tmp_path / "test.npz")
+        self._mock_dialog(monkeypatch, out, "Numpy archive (*.npz)")
+        w.toolbar.save_data()
+        data = np.load(out)
+        assert str(data["plot_type"]) == "pcolormesh"
+        assert str(data["shading"]) == "flat"
+        assert_allclose(data["z_data_0"], z)
+        assert len(data["x_edges_0"]) == len(x_edges)
+        assert len(data["y_edges_0"]) == len(y_edges)
+
+    # -- pcolormesh saves (gouraud shading, 2D node grids) --
+
+    def test_detect_pcolormesh_gouraud(self, qtbot):
+        w = self._make_widget(qtbot)
+        x2d = np.array([[0, 1, 3], [0.5, 1.5, 3.5], [1, 2, 4]], dtype=float)
+        y2d = np.array([[0, 0.1, 0.3], [1, 1.1, 1.3], [2, 2.1, 2.3]], dtype=float)
+        z2d = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=float)
+        w.pcolormesh(x2d, y2d, z2d, shading="gouraud")
+        assert _detect_plot_type(w.canvas.ax) == "pcolormesh"
+
+    def test_save_pcolormesh_gouraud_dat(self, qtbot, tmp_path, monkeypatch):
+        """Gouraud xyz output must have ALL z_data points with per-cell coords."""
+        w = self._make_widget(qtbot)
+        # Irregular grid: each row has different x values
+        x2d = np.array([[0, 1, 3], [0.5, 1.5, 3.5], [1, 2, 4]], dtype=float)
+        y2d = np.array([[0, 0.1, 0.3], [1, 1.1, 1.3], [2, 2.1, 2.3]], dtype=float)
+        z2d = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=float)
+        w.pcolormesh(x2d, y2d, z2d, shading="gouraud")
+        out = str(tmp_path / "test.dat")
+        self._mock_dialog(monkeypatch, out)
+        w.toolbar.save_data()
+        text = open(out).read()
+        assert "shading: gouraud" in text
+        assert "grid: 3 3" in text
+        rows = np.loadtxt(out)
+        # 3 rows × 3 cols = 9 data lines, each with true (x, y, z)
+        assert rows.shape == (9, 3)
+        # Row 0: x2d[0,:], y2d[0,:], z2d[0,:]
+        assert_allclose(rows[0], [0.0, 0.0, 1.0])
+        assert_allclose(rows[1], [1.0, 0.1, 2.0])
+        assert_allclose(rows[2], [3.0, 0.3, 3.0])
+        # Row 1: x2d[1,:], y2d[1,:], z2d[1,:]
+        assert_allclose(rows[3], [0.5, 1.0, 4.0])
+        # Last: x2d[2,2], y2d[2,2], z2d[2,2]
+        assert_allclose(rows[8], [4.0, 2.3, 9.0])
+
+    def test_save_pcolormesh_gouraud_npz(self, qtbot, tmp_path, monkeypatch):
+        w = self._make_widget(qtbot)
+        x2d = np.array([[0, 1, 3], [0.5, 1.5, 3.5], [1, 2, 4]], dtype=float)
+        y2d = np.array([[0, 0.1, 0.3], [1, 1.1, 1.3], [2, 2.1, 2.3]], dtype=float)
+        z2d = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=float)
+        w.pcolormesh(x2d, y2d, z2d, shading="gouraud")
+        out = str(tmp_path / "test.npz")
+        self._mock_dialog(monkeypatch, out, "Numpy archive (*.npz)")
+        w.toolbar.save_data()
+        data = np.load(out)
+        assert str(data["plot_type"]) == "pcolormesh"
+        assert str(data["shading"]) == "gouraud"
+        assert_allclose(data["z_data_0"], z2d)
+        assert_allclose(data["x_grid_0"], x2d)
+        assert_allclose(data["y_grid_0"], y2d)
+
+    # -- line saves --
+
+    def test_save_line_dat(self, qtbot, tmp_path, monkeypatch):
+        w = self._make_widget(qtbot)
+        x = np.array([1.0, 2.0, 3.0])
+        y = np.array([4.0, 5.0, 6.0])
+        w.plot(x, y)
+        out = str(tmp_path / "test.dat")
+        self._mock_dialog(monkeypatch, out)
+        w.toolbar.save_data()
+        loaded = np.loadtxt(out)
+        assert_allclose(loaded[:, 0], x)
+        assert_allclose(loaded[:, 1], y)
+
+    # -- error handling --
+
+    def test_save_empty_plot_shows_error(self, qtbot, monkeypatch):
+        w = self._make_widget(qtbot)
+        errors = []
+        monkeypatch.setattr(
+            QtWidgets.QMessageBox,
+            "critical",
+            staticmethod(lambda *_a, **_kw: errors.append(_a)),
+        )
+        w.toolbar.save_data()
+        assert len(errors) == 1
+        assert "empty" in errors[0][2].lower()
+
+    # -- overlay filtering --
+
+    def test_save_imshow_with_overlays_npz(self, qtbot, tmp_path, monkeypatch):
+        w = self._make_widget(qtbot)
+        arr = np.array([[10.0, 20.0], [30.0, 40.0]])
+        w.imshow(arr, extent=[0, 1, 0, 1], update=False)
+        w.canvas.ax.axvline(0.5, color="red")
+        w.canvas.ax.axhline(0.5, color="green")
+        out = str(tmp_path / "test.npz")
+        self._mock_dialog(monkeypatch, out, "Numpy archive (*.npz)")
+        w.toolbar.save_data()
+        data = np.load(out)
+        assert str(data["plot_type"]) == "imshow"
+
+    # -- imshow origin --
+
+    def test_save_imshow_origin_lower(self, qtbot, tmp_path, monkeypatch):
+        w = self._make_widget(qtbot)
+        arr = np.array([[1.0, 2.0], [3.0, 4.0]])
+        w.imshow(arr, extent=[0, 10, 0, 20], origin="lower", update=False)
+        out = str(tmp_path / "test.dat")
+        self._mock_dialog(monkeypatch, out)
+        w.toolbar.save_data()
+        text = open(out).read()
+        assert "origin: lower" in text
+
+    def test_save_imshow_origin_upper(self, qtbot, tmp_path, monkeypatch):
+        w = self._make_widget(qtbot)
+        arr = np.array([[1.0, 2.0], [3.0, 4.0]])
+        w.imshow(arr, extent=[0, 10, 0, 20], origin="upper", update=False)
+        out = str(tmp_path / "test.dat")
+        self._mock_dialog(monkeypatch, out)
+        w.toolbar.save_data()
+        text = open(out).read()
+        assert "origin: upper" in text
+
+    def test_save_imshow_origin_npz(self, qtbot, tmp_path, monkeypatch):
+        w = self._make_widget(qtbot)
+        arr = np.array([[1.0, 2.0], [3.0, 4.0]])
+        w.imshow(arr, extent=[0, 10, 0, 20], origin="lower", update=False)
+        out = str(tmp_path / "test.npz")
+        self._mock_dialog(monkeypatch, out, "Numpy archive (*.npz)")
+        w.toolbar.save_data()
+        data = np.load(out, allow_pickle=True)
+        assert str(data["origin"]) == "lower"
+
+    # -- round-trip tests --
+
+    def test_roundtrip_errorbar_dat(self, qtbot, tmp_path, monkeypatch):
+        """Write errorbar .dat, read back, verify X/Y/E match."""
+        w = self._make_widget(qtbot)
+        x = np.array([1.0, 2.0, 3.0])
+        y = np.array([10.0, 20.0, 30.0])
+        e = np.array([0.5, 1.0, 1.5])
+        w.errorbar(x, y, yerr=e)
+        out = str(tmp_path / "rt.dat")
+        self._mock_dialog(monkeypatch, out)
+        w.toolbar.save_data()
+        loaded = np.loadtxt(out)
+        assert_allclose(loaded[:, 0], x)
+        assert_allclose(loaded[:, 1], y)
+        assert_allclose(loaded[:, 2], e)
+
+    def test_roundtrip_line_dat(self, qtbot, tmp_path, monkeypatch):
+        """Write line .dat, read back, verify X/Y match."""
+        w = self._make_widget(qtbot)
+        x = np.array([0.5, 1.5, 2.5, 3.5])
+        y = np.array([10.0, 20.0, 15.0, 25.0])
+        w.plot(x, y)
+        out = str(tmp_path / "rt.dat")
+        self._mock_dialog(monkeypatch, out)
+        w.toolbar.save_data()
+        loaded = np.loadtxt(out)
+        assert_allclose(loaded[:, 0], x)
+        assert_allclose(loaded[:, 1], y)
+
+    def test_roundtrip_imshow_dat(self, qtbot, tmp_path, monkeypatch):
+        """Write imshow .dat, read back with extent+origin, verify array."""
+        w = self._make_widget(qtbot)
+        arr = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+        extent = [0, 30, 0, 20]
+        w.imshow(arr, extent=extent, origin="lower", update=False)
+        out = str(tmp_path / "rt.dat")
+        self._mock_dialog(monkeypatch, out)
+        w.toolbar.save_data()
+        # Read back and verify
+        loaded = np.loadtxt(out)
+        assert_allclose(loaded, arr)
+        text = open(out).read()
+        assert "origin: lower" in text
+        assert "xmin=0" in text
+        assert "xmax=30" in text
+
+    def test_roundtrip_pcolormesh_flat_dat(self, qtbot, tmp_path, monkeypatch):
+        """Write flat pcolormesh .dat, read back as xyz, reconstruct z grid."""
+        w = self._make_widget(qtbot)
+        x_edges = np.array([0.0, 1.0, 2.0, 3.0])
+        y_edges = np.array([0.0, 1.0, 2.0])
+        z = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+        w.pcolormesh(x_edges, y_edges, z)
+        out = str(tmp_path / "rt.dat")
+        self._mock_dialog(monkeypatch, out)
+        w.toolbar.save_data()
+        rows = np.loadtxt(out)
+        xs = np.unique(rows[:, 0])
+        ys = np.unique(rows[:, 1])
+        z_rt = rows[:, 2].reshape(len(xs), len(ys)).T
+        assert_allclose(z_rt, z)
+
+    def test_roundtrip_pcolormesh_gouraud_dat(self, qtbot, tmp_path, monkeypatch):
+        """Write gouraud pcolormesh .dat, read back using grid dims, verify all arrays."""
+        w = self._make_widget(qtbot)
+        x2d = np.array([[0, 1, 3], [0.5, 1.5, 3.5], [1, 2, 4]], dtype=float)
+        y2d = np.array([[0, 0.1, 0.3], [1, 1.1, 1.3], [2, 2.1, 2.3]], dtype=float)
+        z2d = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype=float)
+        w.pcolormesh(x2d, y2d, z2d, shading="gouraud")
+        out = str(tmp_path / "rt.dat")
+        self._mock_dialog(monkeypatch, out)
+        w.toolbar.save_data()
+        # Reconstruct using grid dimensions from header
+        import re
+
+        text = open(out).read()
+        m = re.search(r"grid: (\d+) (\d+)", text)
+        ny, nx = int(m.group(1)), int(m.group(2))
+        rows = np.loadtxt(out)
+        x_rt = rows[:, 0].reshape(ny, nx)
+        y_rt = rows[:, 1].reshape(ny, nx)
+        z_rt = rows[:, 2].reshape(ny, nx)
+        assert_allclose(x_rt, x2d)
+        assert_allclose(y_rt, y2d)
+        assert_allclose(z_rt, z2d)
+
+    def test_roundtrip_all_npz(self, qtbot, tmp_path, monkeypatch):
+        """Verify .npz round-trip for all plot types."""
+        # errorbar
+        w = self._make_widget(qtbot)
+        w.errorbar([1, 2], [3, 4], yerr=[0.1, 0.2])
+        out = str(tmp_path / "eb.npz")
+        self._mock_dialog(monkeypatch, out, "Numpy archive (*.npz)")
+        w.toolbar.save_data()
+        d = np.load(out, allow_pickle=True)
+        assert str(d["plot_type"]) == "errorbar"
+        assert_allclose(d["x_0"], [1, 2])
+
+        # imshow
+        w2 = self._make_widget(qtbot)
+        arr = np.array([[5.0, 6.0], [7.0, 8.0]])
+        w2.imshow(arr, extent=[0, 1, 0, 1], origin="lower", update=False)
+        out2 = str(tmp_path / "im.npz")
+        self._mock_dialog(monkeypatch, out2, "Numpy archive (*.npz)")
+        w2.toolbar.save_data()
+        d2 = np.load(out2, allow_pickle=True)
+        assert str(d2["plot_type"]) == "imshow"
+        assert str(d2["origin"]) == "lower"
+        assert_allclose(d2["data"], arr)
+
+        # pcolormesh gouraud (irregular grid)
+        w3 = self._make_widget(qtbot)
+        x2d = np.array([[0, 1.5], [0.5, 2.0]], dtype=float)
+        y2d = np.array([[0, 0.1], [1, 1.1]], dtype=float)
+        z2d = np.array([[10, 20], [30, 40]], dtype=float)
+        w3.pcolormesh(x2d, y2d, z2d, shading="gouraud")
+        out3 = str(tmp_path / "pm.npz")
+        self._mock_dialog(monkeypatch, out3, "Numpy archive (*.npz)")
+        w3.toolbar.save_data()
+        d3 = np.load(out3)
+        assert str(d3["plot_type"]) == "pcolormesh"
+        assert str(d3["shading"]) == "gouraud"
+        assert_allclose(d3["z_data_0"], z2d)
+        assert_allclose(d3["x_grid_0"], x2d)
+        assert_allclose(d3["y_grid_0"], y2d)
+
+    # -- metadata preservation --
+
+    def test_errorbar_yscale_in_dat(self, qtbot, tmp_path, monkeypatch):
+        """Log y-scale is written to the .dat header."""
+        w = self._make_widget(qtbot)
+        w.errorbar([1, 2], [3, 4], yerr=[0.1, 0.2])
+        w.canvas.ax.set_yscale("log")
+        out = str(tmp_path / "test.dat")
+        self._mock_dialog(monkeypatch, out)
+        w.toolbar.save_data()
+        text = open(out).read()
+        assert "yscale: log" in text
+
+    def test_errorbar_yscale_in_npz(self, qtbot, tmp_path, monkeypatch):
+        w = self._make_widget(qtbot)
+        w.errorbar([1, 2], [3, 4], yerr=[0.1, 0.2])
+        w.canvas.ax.set_yscale("log")
+        out = str(tmp_path / "test.npz")
+        self._mock_dialog(monkeypatch, out, "Numpy archive (*.npz)")
+        w.toolbar.save_data()
+        data = np.load(out, allow_pickle=True)
+        assert str(data["yscale"]) == "log"
+
+    def test_imshow_lognorm_in_dat(self, qtbot, tmp_path, monkeypatch):
+        """LogNorm and cmap are written to the imshow .dat header."""
+        w = self._make_widget(qtbot)
+        w.imshow(np.ones((3, 3)) + 1, log=True, imin=0.1, imax=10, update=False)
+        out = str(tmp_path / "test.dat")
+        self._mock_dialog(monkeypatch, out)
+        w.toolbar.save_data()
+        text = open(out).read()
+        assert "norm: LogNorm" in text
+        assert "cmap:" in text
+
+    def test_pcolormesh_lognorm_in_dat(self, qtbot, tmp_path, monkeypatch):
+        """LogNorm and cmap are written to the pcolormesh .dat header."""
+        w = self._make_widget(qtbot)
+        x = np.array([0.0, 1.0, 2.0, 3.0])
+        y = np.array([0.0, 1.0, 2.0])
+        z = np.ones((2, 3)) + 1
+        w.pcolormesh(x, y, z, log=True, imin=0.1, imax=10)
+        out = str(tmp_path / "test.dat")
+        self._mock_dialog(monkeypatch, out)
+        w.toolbar.save_data()
+        text = open(out).read()
+        assert "norm: LogNorm" in text
+        assert "norm_vmin: 0.1" in text
+        assert "norm_vmax: 10" in text
+
+    def test_errorbar_labels_in_dat(self, qtbot, tmp_path, monkeypatch):
+        """Dataset labels from legend are preserved in the .dat header."""
+        w = self._make_widget(qtbot)
+        w.errorbar([1, 2], [3, 4], yerr=[0.1, 0.2], label="Active")
+        w.errorbar([2, 3], [5, 6], yerr=[0.2, 0.3], label="43279")
+        out = str(tmp_path / "test.dat")
+        self._mock_dialog(monkeypatch, out)
+        w.toolbar.save_data()
+        text = open(out).read()
+        assert "Dataset 0: Active" in text
+        assert "Dataset 1: 43279" in text
+
+    def test_pcolormesh_title_labels_in_dat(self, qtbot, tmp_path, monkeypatch):
+        """Title and axis labels are written to the pcolormesh .dat header."""
+        w = self._make_widget(qtbot)
+        x2d = np.array([[0, 1], [0, 1]], dtype=float)
+        y2d = np.array([[0, 0], [1, 1]], dtype=float)
+        z2d = np.array([[1, 2], [3, 4]], dtype=float)
+        w.pcolormesh(x2d, y2d, z2d, shading="gouraud")
+        w.canvas.ax.set_title("Off_Off")
+        w.canvas.ax.set_xlabel(r"k$_{i,z}$-k$_{f,z}$ [\u00c5$^{-1}$]")
+        w.canvas.ax.set_ylabel(r"Q$_z$ [\u00c5$^{-1}$]")
+        out = str(tmp_path / "test.dat")
+        self._mock_dialog(monkeypatch, out)
+        w.toolbar.save_data()
+        text = open(out).read()
+        assert "title: Off_Off" in text
+        assert "xlabel: k$" in text
+        assert "ylabel: Q$" in text

--- a/test/ui/test_mplwidget.py
+++ b/test/ui/test_mplwidget.py
@@ -660,3 +660,47 @@ class TestSaveData:
         assert "title: Off_Off" in text
         assert "xlabel: k$" in text
         assert "ylabel: Q$" in text
+
+    # -- coverage for edge cases --
+
+    def test_save_errorbar_no_yerr_dat(self, qtbot, tmp_path, monkeypatch):
+        """Errorbar plotted without yerr produces zero error column."""
+        w = self._make_widget(qtbot)
+        w.canvas.ax.errorbar([1, 2, 3], [4, 5, 6])  # no yerr → no bar collections
+        out = str(tmp_path / "test.dat")
+        self._mock_dialog(monkeypatch, out)
+        w.toolbar.save_data()
+        loaded = np.loadtxt(out)
+        assert_allclose(loaded[:, 2], [0, 0, 0])
+
+    def test_save_multi_line_dat(self, qtbot, tmp_path, monkeypatch):
+        """Multiple line datasets are separated by blank lines in .dat."""
+        w = self._make_widget(qtbot)
+        w.plot([1, 2], [3, 4], label="a")
+        w.plot([5, 6], [7, 8], label="b")
+        out = str(tmp_path / "test.dat")
+        self._mock_dialog(monkeypatch, out)
+        w.toolbar.save_data()
+        text = open(out).read()
+        assert "Dataset 0: a" in text
+        assert "Dataset 1: b" in text
+        assert "\n\n" in text  # blank line separator
+
+    def test_save_replaces_unrecognized_extension(self, qtbot, tmp_path, monkeypatch):
+        """Unrecognized extension is replaced, not appended."""
+        w = self._make_widget(qtbot)
+        w.plot([1, 2], [3, 4])
+        out = str(tmp_path / "test.txt")
+        self._mock_dialog(monkeypatch, out)
+        w.toolbar.save_data()
+        assert (tmp_path / "test.dat").exists()
+        assert not (tmp_path / "test.txt.dat").exists()
+
+    def test_save_appends_extension_when_none(self, qtbot, tmp_path, monkeypatch):
+        """Extension is appended when the filename has none."""
+        w = self._make_widget(qtbot)
+        w.plot([1, 2], [3, 4])
+        out = str(tmp_path / "myfile")
+        self._mock_dialog(monkeypatch, out)
+        w.toolbar.save_data()
+        assert (tmp_path / "myfile.dat").exists()

--- a/test/ui/test_mplwidget.py
+++ b/test/ui/test_mplwidget.py
@@ -244,7 +244,7 @@ class TestSaveData:
         w = self._make_widget(qtbot)
         w.errorbar([1, 2], [3, 4], yerr=[0.1, 0.2])
         out = str(tmp_path / "test.pkl")
-        self._mock_dialog(monkeypatch, out, "Pickle (*.pkl)")
+        self._mock_dialog(monkeypatch, out, "Pickle [trusted sources only] (*.pkl)")
         w.toolbar.save_data()
         with open(out, "rb") as f:
             payload = pickle.load(f)

--- a/test/ui/test_mplwidget.py
+++ b/test/ui/test_mplwidget.py
@@ -137,6 +137,22 @@ class TestNavigationToolbar:
         _compare_lines_data(lines, gold_data, is_q4_plot=True)
         _compare_error_bar_data(collections, gold_data, is_q4_plot=True)
 
+    def test_reflectivity_toolbar_q4_with_nan(self, qtbot):
+        """Q^4 toggle does not crash when errorbar data contains NaN (empty segments)."""
+        w = MPLWidget()
+        qtbot.addWidget(w)
+        x = np.array([1.0, 2.0, 3.0, 4.0])
+        y = np.array([10.0, np.nan, 30.0, 40.0])
+        e = np.array([0.5, 1.0, np.nan, 2.0])
+        w.errorbar(x, y, yerr=e)
+        toolbar = w.toolbar
+        # Toggle Q^4 on — should not raise
+        _toggle_toolbar_button(toolbar, "RQ4")
+        assert toolbar.q_pow_4_button.isChecked()
+        # Toggle Q^4 off — should not raise
+        _toggle_toolbar_button(toolbar, "RQ4")
+        assert not toolbar.q_pow_4_button.isChecked()
+
 
 class TestSaveData:
     """Test save_data() across all plot types and output formats."""
@@ -609,6 +625,23 @@ class TestSaveData:
         text = open(out).read()
         assert "Dataset 0: Active" in text
         assert "Dataset 1: 43279" in text
+
+    def test_save_errorbar_with_nan_dat(self, qtbot, tmp_path, monkeypatch):
+        """Errorbar data with NaN values (empty matplotlib segments) saves without error."""
+        w = self._make_widget(qtbot)
+        x = np.array([1.0, 2.0, 3.0, 4.0])
+        y = np.array([10.0, np.nan, 30.0, 40.0])
+        e = np.array([0.5, 1.0, 1.5, np.nan])
+        w.errorbar(x, y, yerr=e)
+        out = str(tmp_path / "test.dat")
+        self._mock_dialog(monkeypatch, out)
+        w.toolbar.save_data()
+        loaded = np.loadtxt(out)
+        assert_allclose(loaded[:, 0], x)
+        # Valid points should have correct data; NaN points produce NaN error
+        assert_allclose(loaded[0, 1], 10.0)
+        assert_allclose(loaded[2, 1], 30.0)
+        assert loaded.shape[0] == 4
 
     def test_pcolormesh_title_labels_in_dat(self, qtbot, tmp_path, monkeypatch):
         """Title and axis labels are written to the pcolormesh .dat header."""


### PR DESCRIPTION
This supercedes https://github.com/neutrons/quicknxs/pull/269

Replace the brittle heuristic-based save_data() in NavigationToolbar with a proper implementation that:

- Detects plot type by inspecting axes content (imshow, pcolormesh, errorbar, line) instead of using modular arithmetic on line count
- Supports three export formats: .dat (ASCII/gnuplot-compatible), .npz (NumPy archive), and .pkl (pickle with full figure)
- Handles pcolormesh with both flat shading (edge arrays) and gouraud shading (irregular 2D grids used in off-specular/GISANS data)
- Preserves plot metadata: axis labels, title, colormap, normalization, scale, origin, extent
- Filters overlay markers (axvline/axhline) from data lines
- Reports errors to the user via QMessageBox instead of silently failing

Add comprehensive test suite (30+ tests) covering all plot types, both export formats, round-trip verification, error handling, overlay filtering, and metadata preservation.

Fixes EWM-15204.

## Description of work:

Check all that apply:
(if not, provide an explanation in the work description)
- [x] updated documentation and checked that it looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [x] Source added/refactored
- [x] Added unit tests
- [x] Added integration tests

**References:**
- Links to IBM EWM items:
- Links to related issues or pull requests:


# :warning: Manual test for the reviewer
([instructions to set up the environment](https://reflectivity-ui.readthedocs.io/en/latest/developer/environment.html))

# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date and looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] code comments added when explaining intent
