### PR TITLE
Fix error in diagnostic widget

### DIFF
--- a/src/quicknxs/interfaces/data_handling/diagnostic_data.py
+++ b/src/quicknxs/interfaces/data_handling/diagnostic_data.py
@@ -4,7 +4,7 @@ from quicknxs.interfaces.data_handling.filepath import FilePath
 
 
 class DiagnosticData(object):
-    """Diagnositc data for a run or group of runs to help understand and debug issues with QuickNXS workspaces"""
+    """Diagnostic data for a run or group of runs to help understand and debug issues with QuickNXS workspaces"""
 
     def __init__(self, file_path: str | list[str] | None = None, message: str | None = None, min_num_evts: int = 100):
         self.min_num_events = min_num_evts

--- a/src/quicknxs/interfaces/data_handling/instrument.py
+++ b/src/quicknxs/interfaces/data_handling/instrument.py
@@ -95,6 +95,7 @@ class CrossSectionError(Exception):
     def __init__(self, file_path: str | list[str] | None = None, message: str | None = None, min_num_evts: int = 100):
         self.min_num_events = min_num_evts
         self.file_path = file_path
+        self.file_name = FilePath(file_path, sort=True).basename if file_path else None
 
         if message is None:
             message = f"No valid cross-sections found in file: {file_path}"

--- a/src/quicknxs/interfaces/data_handling/instrument.py
+++ b/src/quicknxs/interfaces/data_handling/instrument.py
@@ -163,7 +163,7 @@ class Instrument(object):
                 analyzer > 0 and self.ana_state not in event_ws.getRun()
             ):
                 use_slow_flipper_log = True
-                print("\n\nMISSING POLARIZER/ANALYZER META-DATA: USING SLOW LOGS\n\n")
+                logging.warning("\n\nMISSING POLARIZER/ANALYZER META-DATA: USING SLOW LOGS\n")
             # Delete the temporary workspace as split_events will reload it
             api.DeleteWorkspace("raw_events")
         elif not is_pre_epics and not file_path.endswith(".nxs.h5"):
@@ -234,7 +234,7 @@ class Instrument(object):
                             )
                             path_xs_list.append(_ws)
                     if not is_found:
-                        print("Could not find error events for [%s]" % xs_name)
+                        logging.warning(f"Could not find error events for [{xs_name}]")
                         _ws = apply_dead_time_correction(
                             ws,
                             configuration.paralyzable_deadtime,

--- a/src/quicknxs/interfaces/data_manager.py
+++ b/src/quicknxs/interfaces/data_manager.py
@@ -527,7 +527,7 @@ class DataManager(object):
             try:
                 nexus_data.load(progress=sub_task, update_parameters=update_parameters)
             except CrossSectionError as ex:
-                self.bad_files.update(ex.bad_files)
+                self.bad_files.add(ex.file_name)
                 raise
 
         if progress is not None:

--- a/src/quicknxs/interfaces/diagnostic_widget.py
+++ b/src/quicknxs/interfaces/diagnostic_widget.py
@@ -1,5 +1,6 @@
 from qtpy import QtWidgets
 
+from quicknxs.config.gui import QColors
 from quicknxs.interfaces.configuration import Configuration
 from quicknxs.interfaces.data_handling.diagnostic_data import DiagnosticData
 

--- a/src/quicknxs/interfaces/event_handlers/main_handler.py
+++ b/src/quicknxs/interfaces/event_handlers/main_handler.py
@@ -2040,7 +2040,7 @@ class MainHandler:
         error:
             CrossSectionError exception containing diagnostic data
         """
-        diag_data = DiagnosticData(file_path=e.file_path, message=str(e))
-        diagnostic_widget = DiagnosticWidget(parent=main_window)
+        diag_data = DiagnosticData(file_path=error.file_path, message=str(error))
+        diagnostic_widget = DiagnosticWidget(parent=self.main_window)
         diagnostic_widget.show(diag_data)
         self.update_file_list()

--- a/test/unit/quicknxs/interfaces/data_handling/test_instrument.py
+++ b/test/unit/quicknxs/interfaces/data_handling/test_instrument.py
@@ -73,8 +73,12 @@ def test_load_data_insufficient_event_count(data_server):
     conf = Configuration()
     file_path = data_server.path_to("REF_M_43670")
 
-    with pytest.raises(CrossSectionError):
+    with pytest.raises(CrossSectionError) as excinfo:
         conf.instrument.load_data(file_path, conf)
+
+    assert excinfo.value.min_num_events == 100
+    assert excinfo.value.file_name == "REF_M_43670.nxs.h5"
+    assert "REF_M_43670.nxs.h5" in excinfo.value.file_path
 
 
 @pytest.mark.parametrize(

--- a/test/unit/quicknxs/interfaces/event_handlers/test_main_handler.py
+++ b/test/unit/quicknxs/interfaces/event_handlers/test_main_handler.py
@@ -426,5 +426,24 @@ def test_stitch_reflectivity_updates_reduction_table(mocker, qtbot):
     assert handler.reduction_table.item(1, ReductionTableColumn.SCALE_FACTOR).text() == str(scale1)
 
 
+def test_show_diagnostic(mocker, qtbot):
+    """Test that _show_diagnostic creates DiagnosticData and DiagnosticWidget, shows the widget, and updates the file list."""
+    main_window = MainWindow()
+    handler = MainHandler(main_window)
+    qtbot.addWidget(main_window)
+
+    mock_diag_data_cls = mocker.patch("quicknxs.interfaces.event_handlers.main_handler.DiagnosticData")
+    mock_diag_widget_cls = mocker.patch("quicknxs.interfaces.event_handlers.main_handler.DiagnosticWidget")
+    mock_update_file_list = mocker.patch("quicknxs.interfaces.event_handlers.main_handler.MainHandler.update_file_list")
+
+    error = CrossSectionError(file_path=None, message="test diagnostic message")
+    handler._show_diagnostic(error)
+
+    mock_diag_data_cls.assert_called_once_with(file_path=error.file_path, message=str(error))
+    mock_diag_widget_cls.assert_called_once_with(parent=main_window)
+    mock_diag_widget_cls.return_value.show.assert_called_once_with(mock_diag_data_cls.return_value)
+    mock_update_file_list.assert_called_once()
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/test/unit/quicknxs/interfaces/test_data_manager.py
+++ b/test/unit/quicknxs/interfaces/test_data_manager.py
@@ -4,7 +4,7 @@ import pytest
 
 import quicknxs.interfaces.data_handling.data_manipulation as dm
 from quicknxs.interfaces.configuration import Configuration
-from quicknxs.interfaces.data_handling.instrument import Instrument
+from quicknxs.interfaces.data_handling.instrument import CrossSectionError, Instrument
 from quicknxs.interfaces.data_manager import DataManager
 
 
@@ -264,6 +264,33 @@ class TestDataManagerTest(object):
         assert len(manager.reduction_list) == 1
         assert manager.reduction_states is not None
         assert len(manager.reduction_states) > 0
+
+    @pytest.mark.datarepo
+    def test_bad_files_list(self, data_server, mocker):
+        """Test that files that fail to load are tracked in the bad_files list."""
+        manager = DataManager(data_server.directory)
+
+        # Mock loading the file, but use data_server to get the path for the error message
+        mock_exception = CrossSectionError(data_server.path_to("REF_M_43670"))
+        mocker.patch("quicknxs.interfaces.data_manager.NexusData.load", side_effect=mock_exception)
+        with pytest.raises(CrossSectionError):
+            manager.load(data_server.path_to("REF_M_43670"), Configuration())
+        assert len(manager.bad_files) == 1
+        assert "REF_M_43670.nxs.h5" in manager.bad_files
+
+        # Test loading the same bad file again - the bad files list should not grow
+        with pytest.raises(CrossSectionError):
+            manager.load(data_server.path_to("REF_M_43670"), Configuration())
+        assert len(manager.bad_files) == 1
+        assert "REF_M_43670.nxs.h5" in manager.bad_files
+
+        # Test loading a different bad file - should be added to the list
+        mock_exception = CrossSectionError(data_server.path_to("REF_M_42537"))
+        mocker.patch("quicknxs.interfaces.data_manager.NexusData.load", side_effect=mock_exception)
+        with pytest.raises(CrossSectionError):
+            manager.load(data_server.path_to("REF_M_42537"), Configuration())
+        assert len(manager.bad_files) == 2
+        assert "REF_M_42537.nxs.h5" in manager.bad_files
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description of work:

This PR fixes some small issues in the diagnostic widget handling.

Check all that apply:
(if not, provide an explanation in the work description)
- [ ] updated documentation and checked that it looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] Source added/refactored
- [ ] Added unit tests
- [ ] Added integration tests

**References:**
- Links to IBM EWM items: [Defect 15832: [QuickNXS] Diagnostic widget not opening as expected](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=15832)
- Links to related issues or pull requests:


# :warning: Manual test for the reviewer
([instructions to set up the environment](https://reflectivity-ui.readthedocs.io/en/latest/developer/environment.html))

Open run number **45835** in QuickNXS and verify that the diagnostic widget opens. Verify that after closing the diagnostic widget, the run is colored red in the file list and one can proceed to load other runs as expected.

<img width="1322" height="674" alt="image" src="https://github.com/user-attachments/assets/e33566a5-238b-41ce-acb7-23df6ffe99b7" />


# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date and looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] code comments added when explaining intent
