### PR TITLE
Update logging format

### DIFF
--- a/src/quicknxs/config/logging.py
+++ b/src/quicknxs/config/logging.py
@@ -1,0 +1,45 @@
+import logging
+import logging.handlers
+import os
+import sys
+
+
+class OriginFormatter(logging.Formatter):
+    """Display the source module for root logger records."""
+
+    def format(self, record):
+        record.origin = record.module if record.name == "root" else record.name
+        return super().format(record)
+
+
+def setup_logging():
+    log_level = os.environ.get("QUICKNXS_LOGLEVEL", "INFO").upper()
+    if log_level not in ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"):
+        log_level = "INFO"
+
+    logging.getLogger().setLevel(log_level)
+
+    # Shorten level names to 4 characters for better log formatting
+    logging.addLevelName(logging.DEBUG, "DBUG")
+    logging.addLevelName(logging.INFO, "INFO")
+    logging.addLevelName(logging.WARNING, "WARN")
+    logging.addLevelName(logging.ERROR, "ERR")
+    logging.addLevelName(logging.CRITICAL, "CRIT")
+
+    _fmt = "%(asctime)s | %(levelname)-4s | %(origin)-12s | %(message)s"
+    _date_fmt = "%Y-%m-%d %H:%M:%S"
+    LOG_FMT = OriginFormatter(fmt=_fmt, datefmt=_date_fmt)
+
+    # Setup timed rotating file handler
+    fh = logging.handlers.TimedRotatingFileHandler(
+        os.path.join(os.path.expanduser("~"), "quicknxs.log"), when="midnight", backupCount=15
+    )
+    fh.setLevel(log_level)
+    fh.setFormatter(LOG_FMT)
+    logging.getLogger().addHandler(fh)
+
+    # Setup stream handler
+    sh = logging.StreamHandler(sys.stdout)
+    sh.setLevel(log_level)
+    sh.setFormatter(LOG_FMT)
+    logging.getLogger().addHandler(sh)

--- a/src/quicknxs/gui.py
+++ b/src/quicknxs/gui.py
@@ -1,40 +1,20 @@
 #!/usr/bin/env python
 """Start script for reduction application."""
 
-# Set Qt5Agg now so matplotlib doesn't complain later
-import os
-
-os.environ["QT_API"] = "pyqt5"
-import matplotlib
-
-matplotlib.use("Qt5Agg")
-
 import logging
-import logging.handlers
+import os
 import sys
 
-# Log Level as environment variable
-log_level = os.environ.get("QUICKNXS_LOGLEVEL", "INFO").upper()
-if log_level not in ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"):
-    log_level = "INFO"
+import matplotlib
 
-# Set log level
-logging.getLogger().setLevel(log_level)
+from quicknxs.config.logging import setup_logging
 
-# Formatter
-ft = logging.Formatter("%(levelname)s:%(asctime)-15s %(message)s")
-# Create a log file handler
-fh = logging.handlers.TimedRotatingFileHandler(
-    os.path.join(os.path.expanduser("~"), "quicknxs.log"), when="midnight", backupCount=15
-)
-fh.setLevel(log_level)
-fh.setFormatter(ft)
-logging.getLogger().addHandler(fh)
+# Set Qt5Agg now so matplotlib doesn't complain later
+os.environ["QT_API"] = "pyqt5"
+matplotlib.use("Qt5Agg")
 
-sh = logging.StreamHandler(sys.stdout)
-sh.setLevel(log_level)
-sh.setFormatter(ft)
-logging.getLogger().addHandler(sh)
+
+setup_logging()
 
 
 def no_abort_excepthook(exc_type, value, tback):

--- a/test/unit/quicknxs/interfaces/event_handlers/test_main_handler.py
+++ b/test/unit/quicknxs/interfaces/event_handlers/test_main_handler.py
@@ -385,12 +385,12 @@ def test_logging_changes_from_gui(qtbot, monkeypatch):
     qtbot.addWidget(main_window)
 
     # Initial log level should be WARNING
-    assert handler.get_log_level() == "WARNING"
+    assert handler.get_log_level() == "WARN"
     assert logging.getLogger().getEffectiveLevel() == logging.WARNING
 
     # Change log level to DEBUG using the handler method
     handler.change_log_level("DEBUG")
-    assert handler.get_log_level() == "DEBUG"
+    assert handler.get_log_level() == "DBUG"
     assert logging.getLogger().getEffectiveLevel() == logging.DEBUG
 
 

--- a/test/unit/quicknxs/interfaces/test_data_manager.py
+++ b/test/unit/quicknxs/interfaces/test_data_manager.py
@@ -1,5 +1,3 @@
-# local imports
-# 3rd-party imports
 import pytest
 
 import quicknxs.interfaces.data_handling.data_manipulation as dm


### PR DESCRIPTION
Cleans up the logging format to be more readable example output:
```
2026-04-22 13:02:05 | INFO | main_handler | Loading file(s) /home/ge2/dev/ornl/quicknxs/test/data/quicknxs-data/REF_M_42099.nxs.h5
2026-04-22 13:02:07 | INFO | data_set     | /home/ge2/dev/ornl/quicknxs/test/data/quicknxs-data/REF_M_42099.nxs.h5 loaded: 2 xs
2026-04-22 13:02:07 | INFO | data_set     | Loading Off_On: 8726623 events
2026-04-22 13:02:07 | INFO | data_set     | Loading On_On: 180 events
2026-04-22 13:02:07 | INFO | data_info    | Run 42099 [Off_On]: Peak found [189, 201]
2026-04-22 13:02:07 | INFO | data_info    | Run 42099 [Off_On]: Low-res found [np.float64(49.86168172865826), np.float64(204.6356076859552)]
2026-04-22 13:02:07 | WARN | data_info    | Using ROI peak range: [225, 246]
2026-04-22 13:02:07 | WARN | data_info    | Using ROI low-res range: [127, 207]
2026-04-22 13:02:07 | WARN | data_info    | Using ROI background range: [17, 38]
2026-04-22 13:02:07 | INFO | data_info    | INSPECT: 0.14934706687927246 sec
2026-04-22 13:02:07 | INFO | data_manager | Best direct beam for run 42099 is None
2026-04-22 13:02:07 | INFO | data_manager | DataManager.load: No matching direct beam found - match_found=False, direct_beam=None
2026-04-22 13:02:07 | INFO | main_handler | Loaded file(s) REF_M_42099.nxs.h5
2026-04-22 13:02:07 | INFO | main_handler | Active data changed to 42099
2026-04-22 13:02:07 | INFO | data_set     | Plot data generated: 0.5599408149719238 sec
```