### PR TITLE
Sync sigmaY with sigmaX on every change while sigmas are coupled

### DIFF
--- a/src/quicknxs/views/smooth_dialog.py
+++ b/src/quicknxs/views/smooth_dialog.py
@@ -308,6 +308,10 @@ class OffSpecParametersDialog(QtWidgets.QDialog):
             else:
                 self.ui.sigmasCoupled.setChecked(True)
 
+            # Apply coupling before constructing the ellipses: update_settings() cannot
+            # resize them later in this method because self.drawing is still True
+            self.update_sigma_coupling()
+
             # Create sigma ellipses
             sigma_ang = 0.0
             self.sigma_1 = Ellipse(
@@ -327,9 +331,6 @@ class OffSpecParametersDialog(QtWidgets.QDialog):
         if plot.cplot is not None:
             plot.cplot.set_clim([self.INTENSITY_MIN, self.INTENSITY_MAX])
         plot.draw()
-
-        if self.show_smoothing:
-            self.update_sigma_coupling()
 
         self.drawing = False
 

--- a/src/quicknxs/views/smooth_dialog.py
+++ b/src/quicknxs/views/smooth_dialog.py
@@ -61,7 +61,7 @@ class OffSpecParametersDialog(QtWidgets.QDialog):
 
         # Connect signals for smoothing
         if show_smoothing:
-            self.ui.sigmaX.valueChanged.connect(self.update_settings)
+            self.ui.sigmaX.valueChanged.connect(self.update_sigma_coupling)
             self.ui.sigmaY.valueChanged.connect(self.update_settings)
             self.ui.sigmasCoupled.toggled.connect(self.update_sigma_coupling)
             self.ui.rSigmas.valueChanged.connect(self.update_settings)
@@ -390,7 +390,9 @@ class OffSpecParametersDialog(QtWidgets.QDialog):
 
         if self.ui.sigmasCoupled.isChecked():
             self.ui.sigmaY.setEnabled(False)
+            self.ui.sigmaY.blockSignals(True)
             self.ui.sigmaY.setValue(self.ui.sigmaX.value())
+            self.ui.sigmaY.blockSignals(False)
         else:
             self.ui.sigmaY.setEnabled(True)
 

--- a/tests/ui/test_smooth_dialog.py
+++ b/tests/ui/test_smooth_dialog.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import Mock, patch
 
+import numpy as np
 import pytest
 from qtpy import QtWidgets
 
@@ -111,6 +112,58 @@ def test_dialog_smoothing_defaults(dialog_both):
 
     # Check coupling defaults
     assert dialog_both.ui.sigmasCoupled.isChecked()
+
+
+def _fake_reduction_item(state):
+    """Build a mock reduction item with numpy off-specular data (units: 1/A)."""
+    shape = (10, 20)
+    ki_z = np.linspace(0.05, 0.10, shape[0] * shape[1]).reshape(shape)
+    off_spec = Mock()
+    off_spec.ki_z = ki_z
+    off_spec.kf_z = ki_z * 0.5
+    off_spec.Qz = np.linspace(0.1, 0.3, shape[0] * shape[1]).reshape(shape)
+    off_spec.Qx = np.linspace(-0.001, 0.001, shape[0] * shape[1]).reshape(shape)
+    off_spec.S = np.ones(shape)
+    off_spec.dS = np.ones(shape)
+
+    cross_section = Mock()
+    cross_section.off_spec = off_spec
+    cross_section.configuration.cut_first_n_points = 0
+    cross_section.configuration.cut_last_n_points = 0
+
+    item = Mock()
+    item.cross_sections = {state: cross_section}
+    return item
+
+
+def test_initial_draw_ellipses_match_coupled_sigmas(qtbot, mock_main_window):
+    """Test that draw_plot builds the sigma ellipses from the coupled sigma values.
+
+    The Y range is larger than the X range, so the range-derived sigma_y differs
+    from sigma_x; in coupled mode the ellipses must use the coupled value.
+    """
+    state = "Off_Off"
+    mock_main_window.data_manager.reduction_states = [state]
+    mock_main_window.data_manager.reduction_list = [_fake_reduction_item(state)]
+
+    with patch.object(OffSpecParametersDialog, "draw_plot"):
+        dlg = OffSpecParametersDialog(
+            mock_main_window, mock_main_window.data_manager, show_smoothing=True, show_binning=False
+        )
+        qtbot.addWidget(dlg)
+
+    # Coupled mode already active in the default coordinate system, so draw_plot's
+    # own setChecked(True) is a no-op and emits no toggled signal
+    dlg.ui.kizmkfzVSqz.setChecked(True)
+    dlg.ui.sigmasCoupled.setChecked(True)
+
+    dlg.draw_plot()
+
+    sigma_x = dlg.ui.sigmaX.value()
+    assert dlg.ui.sigmaY.value() == sigma_x
+    assert dlg.sigma_1.width == pytest.approx(2 * sigma_x)
+    assert dlg.sigma_1.height == pytest.approx(2 * sigma_x)
+    assert dlg.sigma_3.height == pytest.approx(6 * sigma_x)
 
 
 def test_sigma_y_follows_sigma_x_when_coupled(dialog_smoothing_only):

--- a/tests/ui/test_smooth_dialog.py
+++ b/tests/ui/test_smooth_dialog.py
@@ -113,6 +113,29 @@ def test_dialog_smoothing_defaults(dialog_both):
     assert dialog_both.ui.sigmasCoupled.isChecked()
 
 
+def test_sigma_y_follows_sigma_x_when_coupled(dialog_smoothing_only):
+    """Test that sigmaY tracks every sigmaX change while sigmasCoupled is checked."""
+    dialog_smoothing_only.ui.sigmasCoupled.setChecked(True)
+
+    dialog_smoothing_only.ui.sigmaX.setValue(0.002)
+    assert dialog_smoothing_only.ui.sigmaY.value() == 0.002
+    assert not dialog_smoothing_only.ui.sigmaY.isEnabled()
+
+    dialog_smoothing_only.ui.sigmaX.setValue(0.0007)
+    assert dialog_smoothing_only.ui.sigmaY.value() == 0.0007
+
+
+def test_sigma_y_independent_when_uncoupled(dialog_smoothing_only):
+    """Test that sigmaY keeps its own value when sigmasCoupled is unchecked."""
+    dialog_smoothing_only.ui.sigmasCoupled.setChecked(False)
+    dialog_smoothing_only.ui.sigmaY.setValue(0.004)
+
+    dialog_smoothing_only.ui.sigmaX.setValue(0.001)
+
+    assert dialog_smoothing_only.ui.sigmaY.value() == 0.004
+    assert dialog_smoothing_only.ui.sigmaY.isEnabled()
+
+
 def test_dialog_bin_width_calculation(dialog_binning_only):
     """Test that the Qz bin width is calculated correctly."""
     # Set known values


### PR DESCRIPTION
## Description of work:

Previously `sigmaY` was copied from `sigmaX` only when the `sigmasCoupled` checkbox was toggled on; subsequent `sigmaX` edits left `sigmaY` stale. Route `sigmaX.valueChanged` through `update_sigma_coupling` so the coupled value tracks every change, and block `sigmaY`'s signals during the sync to avoid a redundant redraw.

Check all that apply:
(if not, provide an explanation in the work description)
- [ ] ~~updated documentation and checked that it looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)~~
- [x] Source added/refactored
- [x] Added unit tests
- [ ] ~~Added integration tests~~

**References:**
- Links to IBM EWM items: [Defect 17325: [QuickNXS] Y radius not updating in isotropic mode in the off-specular intensity smoothing dialog](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=17325)
- Links to related issues or pull requests:


# :warning: Manual test for the reviewer
([instructions to set up the environment](https://reflectivity-ui.readthedocs.io/en/latest/developer/environment.html))

# Check list for the reviewer
- [ ] best software practices
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date and looks correct in the [pull request preview](https://docs.readthedocs.com/platform/stable/pull-requests.html)
- [ ] code comments added when explaining intent
